### PR TITLE
Add CI workflow running compile and test on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,10 @@ jobs:
         run: bundle exec rake compile
 
       - name: Report the c2pa-rs version under test
-        run: bundle exec ruby -Ilib -e 'require "c2pa"; puts "c2pa-rs #{C2PA.sdk_version}"'
+        # Block scalar, and no Ruby string interpolation: in a plain YAML
+        # scalar " #" opens a comment, which silently truncates the command.
+        run: |
+          bundle exec ruby -Ilib -e 'require "c2pa"; puts "c2pa-rs " + C2PA.sdk_version'
 
       - name: Run tests
         run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Superseded runs are cancelled rather than left to finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # macOS is not redundant here: the invalid free behind the TIFF crash
+        # (#2) was surfaced by macOS libmalloc, which aborts on a bad free.
+        # glibc may corrupt the heap silently instead, so a Linux-only matrix
+        # could miss that class of bug entirely.
+        os: [ubuntu-latest, macos-latest]
+        ruby: ["3.4"]
+
+    env:
+      # Skip LTO and codegen-units=1 for tests. The release profile in
+      # ext/c2pa_native/Cargo.toml is tuned for shipping, and compiling 425
+      # crates — including OpenSSL from source — with it on every push is
+      # needless. Note this means CI exercises a debug build, which has integer
+      # overflow checks the released artifact does not.
+      RB_SYS_CARGO_PROFILE: dev
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ext/c2pa_native
+
+      - name: Fetch c2pa-rs development certificates
+        # The signing tests need an X.509 certificate chain and key. These are
+        # the public c2pa-rs development fixtures — not secrets. Files signed
+        # with them carry a signingCredential.untrusted warning, which does not
+        # make a manifest invalid.
+        #
+        # -f makes curl exit non-zero on an HTTP error, so a moved or deleted
+        # fixture fails the run. The suite must never quietly skip its signing
+        # tests and report green.
+        run: |
+          curl -sSfL -o test_cert.pem \
+            https://raw.githubusercontent.com/contentauth/c2pa-rs/main/sdk/tests/fixtures/certs/es256.pub
+          curl -sSfL -o test_key.pem \
+            https://raw.githubusercontent.com/contentauth/c2pa-rs/main/sdk/tests/fixtures/certs/es256.pem
+
+      - name: Verify certificates are usable
+        run: |
+          for f in test_cert.pem test_key.pem; do
+            if [ ! -s "$f" ]; then
+              echo "::error::$f is missing or empty — signing tests would not be meaningful"
+              exit 1
+            fi
+          done
+          grep -q "BEGIN CERTIFICATE" test_cert.pem
+          grep -q "BEGIN" test_key.pem
+
+      - name: Compile the native extension
+        run: bundle exec rake compile
+
+      - name: Report the c2pa-rs version under test
+        run: bundle exec ruby -Ilib -e 'require "c2pa"; puts "c2pa-rs #{C2PA.sdk_version}"'
+
+      - name: Run tests
+        run: bundle exec rake test


### PR DESCRIPTION
Closes #3

Adds `.github/workflows/ci.yml`. Until now nothing verified a branch except someone asserting they ran the tests — the same trust problem the rest of this milestone is about. A run produced by the repository is checkable by anyone, including contributors without write access.

### What it does

| | |
|---|---|
| Triggers | push to `main`, and every pull request |
| Matrix | `ubuntu-latest` + `macos-latest`, Ruby 3.4 |
| Build | `RB_SYS_CARGO_PROFILE=dev`, Rust cache keyed on the workspace |
| Certificates | fetched from c2pa-rs development fixtures, then checked for content |
| Cost | $0 — standard runners are free for public repositories |

### Choices worth reviewing

**macOS is deliberate, not habit.** The invalid free behind #2 was surfaced by macOS libmalloc, which aborts on a bad free. glibc may corrupt the heap silently instead, so a Linux-only matrix could miss that whole class of bug.

**Debug profile.** The release profile sets `lto = true` and `codegen-units = 1`, and the tree is 425 crates including OpenSSL compiled from source. Building that on every push is wasteful. The trade-off: CI exercises a debug build, which enables integer overflow checks the released artifact does not — so CI is not testing a byte-identical artifact.

**Certificates are fetched, not committed.** `curl -f` exits non-zero on an HTTP error, so a moved fixture fails the run rather than letting the signing tests skip and report green. Whether to commit them instead — as Adobe does in c2pa-js — is still open in #4.

### Scope

The suite on `main` does not sign anything yet, so this run proves the pipeline compiles the extension and executes tests on both platforms. The certificate steps are in place for the signing tests arriving in #5–#8; #3's criterion about failing rather than skipping becomes meaningful once those land, and is tracked in #4.

Ruby is a single version for now to keep the Actions cache well inside its 10 GB limit — `target/` is ~784 MB per entry. Widening the matrix, and verifying the gemspec's `>= 3.0` floor, is a follow-up.

### Verification

```
bundle exec rake compile && bundle exec rake test
```

Checked locally before pushing: workflow YAML parses, both certificate URLs resolve, and the fetched pair signs a fixture that reads back `Valid`.