### PR TITLE
Cover character and encoding handling, and close an error-contract leak

### DIFF
--- a/lib/c2pa/manifest.rb
+++ b/lib/c2pa/manifest.rb
@@ -66,7 +66,8 @@ module C2PA
     # Serialize to the JSON structure expected by c2pa-rs.
     #
     # @return [String]
-    # @raise [C2PA::InvalidManifestError] if no actions have been added
+    # @raise [C2PA::InvalidManifestError] if no actions have been added, or if
+    #   any value cannot be represented as JSON
     def to_json
       raise InvalidManifestError, "at least one action is required" if @actions.empty?
 
@@ -79,7 +80,16 @@ module C2PA
       }
       manifest["ingredients"] = @ingredients unless @ingredients.empty?
 
-      JSON.generate(manifest)
+      begin
+        JSON.generate(manifest)
+      rescue JSON::GeneratorError => e
+        # Typically a string that is not valid UTF-8 — a filename or caption
+        # read in another encoding and passed through untouched. Without this
+        # the caller gets a JSON::GeneratorError, which is not a C2PA::Error
+        # and so escapes `rescue C2PA::Error`.
+        raise InvalidManifestError,
+              "manifest contains text that cannot be encoded as JSON: #{e.message}"
+      end
     end
   end
 end

--- a/test/c2pa_test.rb
+++ b/test/c2pa_test.rb
@@ -319,6 +319,86 @@ class C2PATest < Minitest::Test
                     "0.78.4 and can resolve atree 0.5.3, which aborts the process on TIFF input"
   end
 
+  # ─── Character and encoding handling ───────────────────────────────────────
+  #
+  # Text passes through Ruby JSON generation, the magnus boundary, and CBOR
+  # encoding inside the C2PA container. Any of those could mangle it.
+  #
+  # Mirrors "should preserve JSON assertion characters without escaping" in
+  # contentauth/c2pa-js Builder.spec.ts.
+
+  # Built from codepoints so this file contains no literal control bytes.
+  def codepoint(number) = number.chr(Encoding::UTF_8)
+
+  def assert_title_survives(title, message)
+    read_back(created_manifest(title: title)) do |active, _|
+      assert_equal title, active["title"], message
+    end
+  end
+
+  def test_quotes_and_backslashes_survive_signing
+    assert_title_survives(%q(He said "hi" \ then \\ left), "quotes or backslashes were mangled")
+  end
+
+  def test_non_ascii_scripts_survive_signing
+    assert_title_survives("Solnedgång 日没 Закат مغيب", "non-ASCII text was mangled")
+  end
+
+  def test_emoji_survive_signing
+    # A ZWJ sequence is several codepoints the reader must not split or reorder.
+    family = [0x1F468, 0x200D, 0x1F469, 0x200D, 0x1F467].map { |c| codepoint(c) }.join
+    assert_title_survives("sunset #{codepoint(0x1F305)} family #{family}", "emoji were mangled")
+  end
+
+  def test_control_characters_survive_signing
+    title = "bell#{codepoint(7)} del#{codepoint(127)} vtab#{codepoint(11)}"
+    assert_title_survives(title, "control characters were mangled")
+  end
+
+  # A NUL is the classic place for a Rust/C boundary to truncate a string.
+  def test_embedded_nul_survives_signing
+    assert_title_survives("before#{codepoint(0)}after", "text was truncated at the NUL")
+  end
+
+  def test_separators_and_bom_survive_signing
+    title = "#{codepoint(0xFEFF)}line#{codepoint(0x2028)}separator"
+    assert_title_survives(title, "BOM or line separator was mangled")
+  end
+
+  def test_long_title_survives_signing
+    assert_title_survives("A" * 4096, "a 4 KB title did not survive")
+  end
+
+  def test_json_like_text_is_not_reinterpreted
+    assert_title_survives('{"not":"json","really":[1,2]}', "JSON-looking text was reinterpreted")
+  end
+
+  def test_special_characters_in_assertion_data_survive_signing
+    description = "quotes \"here\", a \\ backslash,\na newline and\ta tab"
+    manifest = created_manifest.add_assertion(
+      label: "stds.schema-org.CreativeWork",
+      data: { "@context" => "https://schema.org", "description" => description }
+    )
+
+    read_back(manifest) do |active, _|
+      creative_work = active.fetch("assertions")
+                            .find { |a| a["label"] == "stds.schema-org.CreativeWork" }
+      assert_equal description, creative_work.dig("data", "description")
+    end
+  end
+
+  # Invalid UTF-8 is the one input that cannot round-trip. It must still fail as
+  # a C2PA::Error, since the README tells callers that rescuing C2PA::Error is
+  # sufficient. See #28.
+  def test_invalid_utf8_raises_a_c2pa_error
+    title = (+"bad").concat(255.chr).concat("byte")
+    manifest = C2PA::Manifest.new(title: title).add_action(C2PA::Actions::CREATED)
+
+    error = assert_raises(C2PA::InvalidManifestError) { manifest.to_json }
+    assert_kind_of C2PA::Error, error, "callers rescue C2PA::Error and must catch this"
+    assert_match(/\\xFF/i, error.message, "the offending byte should still be identified")
+  end
+
   # ─── Round trip: what actually lands in the signed file ────────────────────
 
   def test_title_survives_signing


### PR DESCRIPTION
Closes #8
Closes #28

Text passes through Ruby JSON generation, the magnus boundary, and CBOR encoding inside the C2PA container. None of it was tested.

## Everything survives

| Input | Result |
|---|---|
| Quotes and backslashes | intact |
| Non-ASCII scripts (Swedish, Japanese, Russian, Arabic) | intact |
| Emoji, including a ZWJ family sequence | intact |
| Control characters (bell, DEL, vertical tab) | intact |
| **Embedded NUL** | intact |
| BOM and U+2028 line separator | intact |
| 4 KB title | intact |
| JSON-looking text | not reinterpreted |
| Newlines, tabs, quotes in assertion data | intact |

The NUL case earns its place: a Rust/C boundary is exactly where a string gets silently truncated, and this one doesn't.

## The one real finding

Invalid UTF-8 is the single input that cannot round-trip — and it was **escaping the documented error contract**. The README says:

> All errors inherit from `C2PA::Error`, so you can rescue broadly or narrowly.

But `JSON.generate` raises `JSON::GeneratorError`, which is not a `C2PA::Error`:

```
class:     JSON::GeneratorError
ancestors: JSON::GeneratorError < JSON::JSONError < StandardError
C2PA::Error? false
```

So `rescue C2PA::Error` never fired. A realistic route in is a filename or caption read in another encoding and passed straight through as a title. `Manifest#to_json` now translates it to `InvalidManifestError`, keeping the offending byte in the message, which makes the README's claim true.

## Verified to fail (#10 discipline)

| Mutation | Result |
|---|---|
| Normalise title to NFD | 2 failures |
| Lossily re-encode title | 1 failure |
| Stop wrapping `JSON::GeneratorError` | 1 failure |
| Strip NUL bytes from title | 1 failure |
| *(control)* | **0 failures** |

**One of these is worth recording.** The NUL mutation first appeared to *pass* — which would have meant my NUL test was worthless. The mutation was wrong: a perl escape that deleted backslash-zero rather than an actual NUL. Rewritten correctly it fails exactly `test_embedded_nul_survives_signing`.

A mutation that doesn't do what you think produces false confidence just as readily as a weak test does. Worth carrying into #10.

47 runs, 145 assertions, 0 failures, 0 skips.

## Verification

```
bundle exec rake test
```