### PR TITLE
Write down the testing rule

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!--
+Closes #NNN
+
+See CONTRIBUTING.md for the testing rule. The short version: a test that
+cannot fail is decoration, so show that it can.
+-->
+
+## What this changes
+
+## Verification
+
+```
+bundle exec rake test
+```
+
+## Tests were shown to fail
+
+<!--
+For each behaviour covered, name the mutation that made the test fail and the
+result. Delete this section only if the change adds no tests.
+
+| Mutation | Result |
+|---|---|
+| Reversed the title in `Manifest#to_json` | 1 failure |
+| _(control, unmutated)_ | 0 failures |
+
+Check the mutated source actually says what you meant before trusting a pass —
+a mutation that does nothing looks exactly like a test that works.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,117 @@
+# Contributing
+
+## Running the tests
+
+```bash
+bundle install
+bundle exec rake test
+```
+
+That compiles the native extension, generates signing certificates, and runs
+the suite. A clean checkout needs no manual setup and no network access.
+
+Regenerating the media fixtures is the one thing that needs extra tooling, and
+only if you are changing them:
+
+```bash
+brew install ffmpeg webp jpeg-xl exiftool   # macOS
+./test/fixtures/generate.sh
+```
+
+## The testing rule
+
+**Every test must be shown to fail.** Break the code it covers on purpose,
+confirm the test catches it, put the evidence in the pull request.
+
+This is not a general principle borrowed from somewhere. It comes from this
+repository's own history. Version 0.2.1 shipped with a green test suite, and
+that suite passed while the gem:
+
+- aborted the Ruby process on any TIFF input
+- emitted manifests that modern verifiers reject
+- advertised PDF signing, which c2pa-rs cannot do at any version
+- documented an editing workflow that has never produced a valid file
+
+The suite passed because its assertions compared the code to itself:
+
+```ruby
+assert_equal "c2pa.created", C2PA::Actions::CREATED   # a literal equals itself
+assert_equal "c2pa.created", actions[0]["action"]     # JSON contains what we put in
+```
+
+Ten tests, and not one of them could have failed for any of those defects. A
+test that cannot fail is decoration.
+
+### How to check
+
+Change the implementation so the behaviour under test is wrong, run the suite,
+confirm the right test fails, then restore:
+
+```ruby
+# lib/c2pa/manifest.rb
+"title" => @title.reverse,   # deliberately wrong
+```
+
+```bash
+bundle exec ruby -Ilib -Itest test/c2pa_test.rb
+git checkout -- lib/c2pa/manifest.rb
+```
+
+Then state it in the pull request:
+
+> Verified by reversing the title in `Manifest#to_json`: 19 failures, against 0
+> for the unmutated suite.
+
+A broad mutation like that trips many tests, which is fine. A narrow one that
+trips exactly the test you just wrote is better evidence, because it shows the
+test is specific as well as present.
+
+Mutating the Rust in `ext/c2pa_native/` counts double — it proves the test
+reaches through the FFI boundary rather than stopping at Ruby.
+
+### Two traps, both hit while building this suite
+
+**A mutation that does not do what you think.** A NUL-handling test appeared to
+survive a mutation that stripped NUL bytes, which would have meant the test was
+worthless. The mutation was wrong — a shell escape that deleted backslash-zero
+rather than an actual NUL. Written correctly, the test failed immediately.
+Prefer editing the file directly over shell substitution, and check the mutated
+source before trusting the result.
+
+**A harness that only fails one way.** For tests that assert on an external
+verdict rather than on our own code, mutate in both directions. A harness made
+to report no failures and a harness made to report spurious ones fail different
+tests; checking only one leaves the other half unverified.
+
+## Where there is no oracle
+
+Most assertions can be checked against c2pa-rs, by signing a file and reading
+back its verdict. Some cannot, and those must say so rather than pretend:
+
+- **Action names** — c2pa-rs does not validate them. `acme.nonsense` signs and
+  reads back clean, so `C2PA::Actions` can only be checked for duplicates and a
+  correct namespace.
+- **Digital source types** — any string is accepted, so the constants are only
+  as good as the IPTC vocabulary they were transcribed from.
+
+Where a rule is enforced more strictly here than by c2pa-rs, label it as a
+deliberate divergence and add a test that fails when upstream changes its mind.
+The gem may be stricter than the SDK; it may not claim the SDK agrees.
+
+## Working on an issue
+
+Issues are grouped into sprints by label and tracked against a release
+milestone. Each carries acceptance criteria and a verification command.
+
+```bash
+git checkout -b fix/42-short-description
+# ...
+gh pr create --milestone "<milestone>" --label "<sprint label>"
+```
+
+Reference the issue with `Closes #42` so it closes on merge. CI runs the suite
+on Linux and macOS for every pull request; both must pass.
+
+macOS is not redundant in that matrix. The invalid free behind the TIFF crash
+was surfaced by macOS libmalloc, which aborts on a bad free where glibc may
+corrupt the heap silently.

--- a/README.md
+++ b/README.md
@@ -330,6 +330,13 @@ The Rust extension (`ext/c2pa_native/src/lib.rs`) defines `C2PA::Native` with th
 
 Input validation (missing files, invalid manifests) is handled in Ruby before calling into Rust. Errors from the native layer are caught and re-raised as typed `C2PA::Error` subclasses.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). The short version: every test must be
+shown to fail before it is merged. The suite that shipped with 0.2.1 passed
+while the gem crashed the Ruby process on TIFF input, so a green run is only
+worth what its assertions can catch.
+
 ## License
 
 MIT

--- a/test/c2pa_test.rb
+++ b/test/c2pa_test.rb
@@ -1,3 +1,10 @@
+# Every test here must be able to fail. Before adding one, break the code it
+# covers on purpose and confirm this suite catches it — see CONTRIBUTING.md.
+#
+# That rule exists because the original suite passed while the gem aborted the
+# Ruby process on TIFF input and emitted manifests that verifiers reject. Its
+# assertions compared the code to itself, so none of them could have failed.
+
 require "minitest/autorun"
 require "tmpdir"
 require "tempfile"


### PR DESCRIPTION
Closes #10

Sprint 1 has been following a discipline that existed only in pull request descriptions: every test must be shown to fail before it is merged. This writes it down so it outlasts whoever happened to be working on it.

## What's added

**`CONTRIBUTING.md`** — the rule, the recipe, and why it exists in terms of this repository rather than as general advice. The 0.2.1 suite passed while the gem aborted the Ruby process on TIFF input, emitted manifests verifiers reject, and advertised PDF signing that c2pa-rs cannot do at any version. It passed because its assertions compared the code to itself:

```ruby
assert_equal "c2pa.created", C2PA::Actions::CREATED   # a literal equals itself
```

**`.github/pull_request_template.md`** — asks for the mutation evidence, so recording it doesn't depend on the author remembering.

**A header on the test file** and a README pointer.

## The two traps, both hit while building this suite

**A mutation that doesn't do what you think.** The NUL test in #29 appeared to survive a mutation that stripped NUL bytes — which would have meant the test was worthless. The mutation was wrong: a shell escape deleting backslash-zero rather than an actual NUL. Written correctly, the test failed immediately. It looks identical from the outside to a test that genuinely works, so the guidance is to edit the file directly rather than use shell substitution, and to read the mutated source before trusting a pass.

**A harness that only fails one way.** For tests asserting on an external verdict, mutate both directions. In #30, a harness made to report no failures trips 7 tests and one made to report spurious failures trips 6 — different sets. Checking one leaves the other half unverified.

## Where there is no oracle

Recorded explicitly, because pretending otherwise is how the original suite went wrong: c2pa-rs validates neither action names nor digital source type strings, so those tables can only be checked for duplicates and namespacing. The tests say so in comments rather than implying more.

Also stated: the gem may be stricter than the SDK, but it may not claim the SDK agrees. Divergences get a test that fails when upstream changes its mind.

## Verification

The documented recipe was run rather than assumed:

| Mutation | Result |
|---|---|
| Reversed the title in `Manifest#to_json` | 19 failures |
| *(control)* | 0 failures |

`git checkout --` restores it as described. Every command in CONTRIBUTING.md was checked to exist — `rake test`, `rake fixtures:certs`, and `./test/fixtures/generate.sh` (executable).

59 runs, 168 assertions, 0 failures, 0 skips. No test changes in this PR, so no new mutation evidence is required.