### PR TITLE
Verify signed output before returning from C2PA.sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,28 @@ C2PA.sign(
 )
 ```
 
+`C2PA.sign` reads the signed file back and confirms it validates before
+returning. If it does not, the output file is deleted and a
+`C2PA::SigningError` is raised naming the failure codes.
+
+This matters because c2pa-rs applies its rules when *reading*, not when
+writing. Signing reports success for manifests that every verifier rejects,
+which is exactly what earlier versions of this gem did — silently, for months.
+The check costs one extra read of the output.
+
+Turn it off with `verify: false` if you want the file kept for inspection:
+
+```ruby
+C2PA.sign(
+  file:        "photo.jpg",
+  output:      "photo_signed.jpg",
+  certificate: "cert.pem",
+  key:         "key.pem",
+  manifest:    manifest,
+  verify:      false
+)
+```
+
 Specify a different signing algorithm with `algorithm:` (default is `"es256"`):
 
 ```ruby

--- a/lib/c2pa.rb
+++ b/lib/c2pa.rb
@@ -6,6 +6,13 @@ require_relative "c2pa/manifest"
 require "c2pa/c2pa_native"
 
 module C2PA
+  # Validation states that mean a signed asset is good.
+  #
+  # "Trusted" is "Valid" plus a signing certificate that chains to a root in
+  # the active trust list. Accepting only "Valid" would reject exactly the
+  # production files that are most correct.
+  VALID_STATES = %w[Valid Trusted].freeze
+
   # Sign a file with a C2PA manifest.
   #
   # @param file        [String]          path to the input file
@@ -14,7 +21,10 @@ module C2PA
   # @param key         [String]          path to a PEM-encoded private key
   # @param algorithm   [String]          signing algorithm (default: "es256")
   # @param manifest    [C2PA::Manifest]  the manifest to embed
+  # @param verify      [Boolean]         read the signed file back and confirm it
+  #                                      validates (default: true)
   # @return            [String]          the output path
+  # @raise [C2PA::SigningError] if signing fails, or if the signed file does not validate
   #
   # @example
   #   manifest = C2PA::Manifest.new(title: "Sunset over the bay")
@@ -27,7 +37,7 @@ module C2PA
   #     key:         "key.pem",
   #     manifest:    manifest
   #   )
-  def self.sign(file:, output:, certificate:, key:, algorithm: "es256", manifest:)
+  def self.sign(file:, output:, certificate:, key:, algorithm: "es256", manifest:, verify: true)
     manifest_json = manifest.to_json
 
     raise SigningError, "Source file not found: '#{file}'"             unless File.exist?(file)
@@ -35,9 +45,15 @@ module C2PA
     raise SigningError, "Key file not found: '#{key}'"                 unless File.exist?(key)
     raise SigningError, "Output file already exists: '#{output}'"      if File.exist?(output)
 
-    Native.sign_file(file, output, certificate, key, algorithm, manifest_json)
-  rescue RuntimeError => e
-    raise SigningError, e.message
+    begin
+      Native.sign_file(file, output, certificate, key, algorithm, manifest_json)
+    rescue RuntimeError => e
+      raise SigningError, e.message
+    end
+
+    verify_signed_output!(output) if verify
+
+    output
   end
 
   # Read the C2PA manifest embedded in a signed file.
@@ -62,4 +78,48 @@ module C2PA
   def self.sdk_version
     Native.sdk_version
   end
+
+  # Read a freshly signed file back and confirm it actually validates.
+  #
+  # Signing reports success for manifests that verifiers reject. c2pa-rs
+  # applies its rules when reading, not when writing, so without this the gem
+  # hands back a path to a file that fails everywhere else — which is what
+  # released versions did, for years, silently.
+  #
+  # The rejected file is deleted rather than left behind, so a failed sign
+  # cannot leave something shippable on disk.
+  #
+  # @param output [String] path to the signed file
+  # @raise [C2PA::SigningError] if the file does not validate
+  def self.verify_signed_output!(output)
+    result =
+      begin
+        read(file: output)
+      rescue ReadError => e
+        discard(output)
+        raise SigningError, "signed file failed verification: could not read it back: #{e.message}"
+      end
+
+    state = result["validation_state"]
+    return if VALID_STATES.include?(state)
+
+    failures = Array(result.dig("validation_results", "activeManifest", "failure"))
+               .map { |failure| "#{failure["code"]} (#{failure["explanation"]})" }
+    detail = failures.empty? ? "no failure detail reported" : failures.uniq.join(", ")
+
+    discard(output)
+    raise SigningError,
+          "signed file failed verification: validation_state=#{state.inspect}, #{detail}. " \
+          "The output file has been removed. Pass verify: false to keep it for inspection."
+  end
+  private_class_method :verify_signed_output!
+
+  # Remove a file this library created and is about to reject.
+  def self.discard(path)
+    File.delete(path) if File.exist?(path)
+  rescue SystemCallError
+    # Leaving the file behind is better than masking the original failure.
+    nil
+  end
+  private_class_method :discard
 end

--- a/test/c2pa_test.rb
+++ b/test/c2pa_test.rb
@@ -326,6 +326,85 @@ class C2PATest < Minitest::Test
                     "0.78.4 and can resolve atree 0.5.3, which aborts the process on TIFF input"
   end
 
+  # ─── Verify after signing ──────────────────────────────────────────────────
+  #
+  # c2pa-rs applies its rules when reading, not when writing, so signing
+  # succeeds for manifests that every verifier rejects. Released versions of
+  # this gem did exactly that, silently, for months.
+  #
+  # The guard is the structural fix: it does not depend on anyone anticipating
+  # which rule will tighten next.
+
+  # A manifest that bypasses Manifest entirely, so the guard is exercised as an
+  # independent backstop rather than a restatement of the builder's rules. The
+  # opened-without-ingredient shape is rejected by every c2pa-rs this gem has
+  # supported, so it stays meaningful across version bumps.
+  def unchecked_invalid_manifest
+    raw = Object.new
+    def raw.to_json
+      JSON.generate("title" => "unchecked",
+                    "assertions" => [{ "label" => "c2pa.actions.v2",
+                                       "data" => { "actions" => [{ "action" => "c2pa.opened" }] } }])
+    end
+    raw
+  end
+
+  def test_signing_an_invalid_manifest_raises_and_removes_the_output
+    assert_certificates_present
+    dir = Dir.mktmpdir
+    output = File.join(dir, "signed.jpg")
+
+    error = assert_raises(C2PA::SigningError) do
+      C2PA.sign(file: File.join(FIXTURES, "tiny.jpg"), output: output,
+                certificate: CERT, key: KEY, manifest: unchecked_invalid_manifest)
+    end
+
+    assert_match(/failed verification/, error.message)
+    assert_match(/assertion\.action\.ingredientMismatch/, error.message,
+                 "the failure codes should be named, not just the state")
+    refute File.exist?(output), "an invalid signed file must not be left on disk"
+  ensure
+    FileUtils.remove_entry(dir) if dir && File.exist?(dir)
+  end
+
+  def test_verify_false_keeps_the_invalid_file_for_inspection
+    assert_certificates_present
+    dir = Dir.mktmpdir
+    output = File.join(dir, "signed.jpg")
+
+    C2PA.sign(file: File.join(FIXTURES, "tiny.jpg"), output: output,
+              certificate: CERT, key: KEY, manifest: unchecked_invalid_manifest,
+              verify: false)
+
+    assert File.exist?(output), "verify: false should leave the file alone"
+    assert_equal "Invalid", C2PA.read(file: output)["validation_state"]
+  ensure
+    FileUtils.remove_entry(dir) if dir && File.exist?(dir)
+  end
+
+  def test_a_valid_manifest_passes_the_guard_and_returns_the_output_path
+    assert_certificates_present
+    dir = Dir.mktmpdir
+    output = File.join(dir, "signed.jpg")
+
+    returned = C2PA.sign(file: File.join(FIXTURES, "tiny.jpg"), output: output,
+                         certificate: CERT, key: KEY, manifest: created_manifest)
+
+    assert_equal output, returned
+    assert File.exist?(output)
+  ensure
+    FileUtils.remove_entry(dir) if dir && File.exist?(dir)
+  end
+
+  # The development certificates are untrusted by design, so every signing test
+  # here runs against state "Valid" rather than "Trusted". A guard accepting
+  # only "Valid" would pass this whole suite and then reject the correctly
+  # trusted files real users produce.
+  def test_trusted_is_accepted_as_well_as_valid
+    assert_includes C2PA::VALID_STATES, "Valid"
+    assert_includes C2PA::VALID_STATES, "Trusted"
+  end
+
   # ─── Conformance: what c2pa-rs actually enforces ───────────────────────────
   #
   # These sign manifests the builder would not produce, bypassing it entirely,
@@ -365,8 +444,10 @@ class C2PATest < Minitest::Test
 
     dir = Dir.mktmpdir
     output = File.join(dir, "signed.jpg")
+    # verify: false — the point of this helper is to produce invalid files and
+    # inspect them, which is exactly what the guard exists to prevent.
     C2PA.sign(file: File.join(FIXTURES, "tiny.jpg"), output: output,
-              certificate: CERT, key: KEY, manifest: unchecked)
+              certificate: CERT, key: KEY, manifest: unchecked, verify: false)
 
     Array(C2PA.read(file: output).dig("validation_results", "activeManifest", "failure"))
       .map { |failure| failure["code"] }


### PR DESCRIPTION
Closes #12

c2pa-rs applies its rules when **reading**, not when writing. Signing reports success for manifests every verifier rejects — which is exactly what released versions of this gem did. 0.2.1 signs files that fail validation, and nothing in the library noticed.

`C2PA.sign` now reads the file back, checks its validation state, and raises `SigningError` naming the failure codes if it doesn't validate. The rejected file is deleted, so a failed sign can't leave something shippable on disk.

```
C2PA::SigningError: signed file failed verification: validation_state="Invalid",
assertion.action.ingredientMismatch (opened, placed and removed items must have
ingredient(s) parameters). The output file has been removed. Pass verify: false
to keep it for inspection.
```

## Why this is the important one

Every defect this milestone found was caught by reading a file back and checking its verdict. Doing that on every sign means the class is closed without anyone having to anticipate which rule tightens next — the next spec change fails at signing time rather than months later in someone else's verifier.

## Trusted, not just Valid

The guard accepts both. `Trusted` is `Valid` plus a certificate chaining to a root in the active trust list.

A guard admitting only `Valid` would have passed this entire suite — the development certificates are untrusted by design, so every test here produces `Valid` — and then rejected the correctly trusted files real users produce. There's an explicit test for it, because that mistake is otherwise invisible in this repository.

## The conformance harness needed the opt-out

`failure_codes_for` deliberately signs invalid manifests to inspect their codes, so it now passes `verify: false`. That it needed the escape hatch is itself evidence the guard does what it claims.

## Verified to fail (#10 discipline)

Five mutations, each producing exactly one failure — narrow rather than broad, which CONTRIBUTING notes is the better evidence:

| Mutation | Result |
|---|---|
| Guard accepts `Invalid` too | 1 failure |
| Guard accepts only `Valid`, not `Trusted` | 1 failure |
| Guard never runs | 1 failure |
| Rejected file left on disk | 1 failure |
| Failure codes omitted from the message | 1 failure |
| *(control)* | **0 failures** |

63 runs, 182 assertions, 0 failures, 0 skips.

## Breaking change

`C2PA.sign` now raises where it previously returned, for anyone currently producing manifests that don't validate. That's the point, and it belongs in the 0.3.0 CHANGELOG (#21).

## Verification

```
bundle exec rake test
```