### PR TITLE
Support editing an existing asset through builder intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,31 @@ manifest.add_action(C2PA::Actions::CREATED)
 Actions can be chained:
 
 ```ruby
-manifest = C2PA::Manifest.new(title: "Edited photo")
-  .add_action(C2PA::Actions::OPENED)
+manifest = C2PA::Manifest.new(title: "Sunset over the bay")
+  .add_action(C2PA::Actions::CREATED)
+  .add_action(C2PA::Actions::PUBLISHED)
+```
+
+### Editing an existing asset
+
+When the file you are signing derives from another one, declare the intent
+rather than adding `c2pa.opened` yourself:
+
+```ruby
+manifest = C2PA::Manifest.new(title: "Edited photo", intent: :edit)
   .add_action(C2PA::Actions::EDITED)
   .add_action(C2PA::Actions::PUBLISHED)
 ```
+
+c2pa-rs derives the parent ingredient from the source file and adds a
+`c2pa.opened` action tied to it, so the signed manifest records
+`c2pa.opened`, `c2pa.edited`, `c2pa.published` and a `parentOf` ingredient.
+
+`c2pa.opened` cannot be added by hand. The specification requires it to
+reference its parent ingredient by hashed URI, and that hash is computed over
+the ingredient as c2pa-rs serialises it — so `add_action(C2PA::Actions::OPENED)`
+raises and points here. Earlier releases of this gem documented adding it
+directly; manifests built that way never validated.
 
 Each action accepts optional fields from the C2PA specification:
 

--- a/ext/c2pa_native/src/lib.rs
+++ b/ext/c2pa_native/src/lib.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use c2pa::{create_signer, Builder, Reader, SigningAlg};
+use c2pa::{create_signer, Builder, BuilderIntent, Reader, SigningAlg};
 use magnus::{function, prelude::*, Error, Ruby};
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -22,6 +22,22 @@ fn alg_from_str(alg: &str) -> Result<SigningAlg, String> {
 
 // ─── Core logic ──────────────────────────────────────────────────────────────
 
+// A c2pa.opened action has to reference its parent ingredient by hashed URI,
+// and that hash is computed over the ingredient assertion as c2pa-rs
+// serialises it. Ruby cannot construct one. Declaring the intent instead lets
+// the SDK derive the parent ingredient from the source and wire the action to
+// it, which is the only way the edit workflow can be expressed.
+fn intent_from_str(intent: &str) -> Result<BuilderIntent, String> {
+    match intent.to_lowercase().as_str() {
+        "edit" => Ok(BuilderIntent::Edit),
+        "update" => Ok(BuilderIntent::Update),
+        _ => Err(format!(
+            "Unknown intent: '{}'. Valid options: edit, update",
+            intent
+        )),
+    }
+}
+
 fn do_sign_file(
     source_path: &str,
     dest_path: &str,
@@ -29,6 +45,7 @@ fn do_sign_file(
     key_path: &str,
     alg_str: &str,
     manifest_json: Option<&str>,
+    intent_str: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let cert = std::fs::read(cert_path)
         .map_err(|e| format!("Cannot read certificate '{}': {}", cert_path, e))?;
@@ -49,6 +66,10 @@ fn do_sign_file(
 
     let mut builder = Builder::from_json(json)
         .map_err(|e| format!("Invalid manifest JSON: {}", e))?;
+
+    if let Some(intent) = intent_str {
+        builder.set_intent(intent_from_str(intent)?);
+    }
 
     builder.sign_file(&*signer, source_path, dest_path)
         .map_err(|e| format!("Signing failed: {}", e))?;
@@ -71,10 +92,11 @@ fn sign_file(
     key: String,
     alg: Option<String>,
     manifest_json: Option<String>,
+    intent: Option<String>,
 ) -> Result<String, Error> {
     let alg_str = alg.as_deref().unwrap_or("es256");
 
-    do_sign_file(&source, &dest, &cert, &key, alg_str, manifest_json.as_deref())
+    do_sign_file(&source, &dest, &cert, &key, alg_str, manifest_json.as_deref(), intent.as_deref())
         .map_err(|e| Error::new(Ruby::get().expect("called from Ruby thread").exception_runtime_error(), e.to_string()))?;
 
     Ok(dest)
@@ -96,7 +118,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     let c2pa = ruby.define_module("C2PA")?;
     let native = c2pa.define_module("Native")?;
 
-    native.define_singleton_method("sign_file", function!(sign_file, 6))?;
+    native.define_singleton_method("sign_file", function!(sign_file, 7))?;
     native.define_singleton_method("read_file", function!(read_file, 1))?;
     native.define_singleton_method("sdk_version", function!(sdk_version, 0))?;
 

--- a/lib/c2pa.rb
+++ b/lib/c2pa.rb
@@ -46,7 +46,10 @@ module C2PA
     raise SigningError, "Output file already exists: '#{output}'"      if File.exist?(output)
 
     begin
-      Native.sign_file(file, output, certificate, key, algorithm, manifest_json)
+      # to_json is the only thing genuinely required of a manifest, so an
+      # object that provides just that still signs — as a creation.
+      intent = manifest.respond_to?(:intent) ? manifest.intent&.to_s : nil
+      Native.sign_file(file, output, certificate, key, algorithm, manifest_json, intent)
     rescue RuntimeError => e
       raise SigningError, e.message
     end

--- a/lib/c2pa/manifest.rb
+++ b/lib/c2pa/manifest.rb
@@ -2,9 +2,34 @@ require "json"
 
 module C2PA
   class Manifest
-    # @param title [String] human-readable title for this asset
-    def initialize(title:)
+    # Intents this gem can express.
+    #
+    # :edit — this asset derives from a parent. c2pa-rs generates the parent
+    #         ingredient from the source file and adds a c2pa.opened action
+    #         wired to it by hashed URI.
+    #
+    # Omitting the intent produces a manifest for a newly created asset.
+    #
+    # c2pa-rs also has an :update intent, a restricted edit for non-editorial
+    # changes. It is not offered here because it requires an ingredient with
+    # real content, and add_ingredient records metadata only — signing with it
+    # fails with "ingredient file not found". Tracked separately.
+    INTENTS = %i[edit].freeze
+
+    # @return [Symbol, nil] the builder intent, if any
+    attr_reader :intent
+
+    # @param title  [String] human-readable title for this asset
+    # @param intent [Symbol, nil] :edit or :update; omit for a new creation
+    # @raise [C2PA::InvalidManifestError] if the intent is not recognised
+    def initialize(title:, intent: nil)
+      unless intent.nil? || INTENTS.include?(intent)
+        raise InvalidManifestError,
+              "unknown intent #{intent.inspect}. Valid options: #{INTENTS.map(&:inspect).join(', ')}"
+      end
+
       @title = title
+      @intent = intent
       @actions = []
       @assertions = []
       @ingredients = []
@@ -26,6 +51,14 @@ module C2PA
                    digital_source_type: nil,
                    changed: nil,
                    parameters: nil)
+      if action == Actions::OPENED
+        raise InvalidManifestError,
+              "#{Actions::OPENED} cannot be added directly. The specification requires it to " \
+              "reference a parentOf ingredient by hashed URI, and that hash is computed over " \
+              "the ingredient as c2pa-rs serialises it, so Ruby cannot construct one. Pass " \
+              "intent: :edit to C2PA::Manifest.new instead and the action will be added for you."
+      end
+
       entry = { "action" => action }
       entry["when"]              = when_time                              if when_time
       entry["softwareAgent"]     = software_agent || "ruby-c2pa/#{VERSION}"

--- a/test/c2pa_test.rb
+++ b/test/c2pa_test.rb
@@ -326,6 +326,83 @@ class C2PATest < Minitest::Test
                     "0.78.4 and can resolve atree 0.5.3, which aborts the process on TIFF input"
   end
 
+  # ─── Editing an existing asset ─────────────────────────────────────────────
+  #
+  # A c2pa.opened action must reference its parent ingredient by hashed URI,
+  # and that hash is computed over the ingredient assertion as c2pa-rs
+  # serialises it. Ruby cannot build one — hand-written attempts fail at build
+  # time with "missing field `hash`".
+  #
+  # Declaring the intent hands the problem to the SDK: it derives the parent
+  # ingredient from the source file and wires the action to it. Without this,
+  # the gem could not express an edit at all, and the README's chaining example
+  # produced files that failed validation from the first release.
+
+  def test_edit_intent_produces_a_valid_manifest
+    manifest = C2PA::Manifest.new(title: "Edited photo", intent: :edit)
+                             .add_action(C2PA::Actions::EDITED)
+
+    read_back(manifest) do |_, result|
+      assert_includes C2PA::VALID_STATES, result["validation_state"]
+    end
+  end
+
+  def test_edit_intent_adds_an_opened_action_before_our_own
+    manifest = C2PA::Manifest.new(title: "Edited photo", intent: :edit)
+                             .add_action(C2PA::Actions::EDITED)
+                             .add_action(C2PA::Actions::PUBLISHED)
+
+    read_back(manifest) do |active, _|
+      assert_equal %w[c2pa.opened c2pa.edited c2pa.published],
+                   signed_actions(active).map { |action| action["action"] }
+    end
+  end
+
+  # The reference the gem cannot construct: a URI plus a hash over the
+  # ingredient. Its presence is the whole point of routing through the intent.
+  def test_edit_intent_wires_the_opened_action_to_a_hashed_uri
+    manifest = C2PA::Manifest.new(title: "Edited photo", intent: :edit)
+                             .add_action(C2PA::Actions::EDITED)
+
+    read_back(manifest) do |active, _|
+      opened = signed_actions(active).first
+      reference = opened.dig("parameters", "ingredients", 0)
+      refute_nil reference, "the opened action carries no ingredient reference"
+      refute_nil reference["url"],  "the reference has no URI"
+      refute_nil reference["hash"], "the reference has no hash"
+    end
+  end
+
+  def test_edit_intent_generates_a_parent_ingredient
+    manifest = C2PA::Manifest.new(title: "Edited photo", intent: :edit)
+                             .add_action(C2PA::Actions::EDITED)
+
+    read_back(manifest) do |active, _|
+      relationships = Array(active["ingredients"]).map { |i| i["relationship"] }
+      assert_includes relationships, "parentOf"
+    end
+  end
+
+  def test_opened_cannot_be_added_directly
+    error = assert_raises(C2PA::InvalidManifestError) do
+      C2PA::Manifest.new(title: "Test").add_action(C2PA::Actions::OPENED)
+    end
+    assert_match(/intent: :edit/, error.message, "the error should point at the supported route")
+  end
+
+  def test_unknown_intent_is_rejected
+    error = assert_raises(C2PA::InvalidManifestError) do
+      C2PA::Manifest.new(title: "Test", intent: :sideways)
+    end
+    assert_match(/unknown intent/i, error.message)
+  end
+
+  def test_omitting_the_intent_still_signs_a_creation
+    read_back(created_manifest) do |active, _|
+      assert_equal %w[c2pa.created], signed_actions(active).map { |a| a["action"] }
+    end
+  end
+
   # ─── Verify after signing ──────────────────────────────────────────────────
   #
   # c2pa-rs applies its rules when reading, not when writing, so signing


### PR DESCRIPTION
Closes #11

Any manifest using `c2pa.opened` produced a file that failed validation, and had done since the first release. The README documented adding the action directly; manifests built that way have never validated.

## Why it couldn't be done in Ruby

The action must reference its parent ingredient by **hashed URI**, and that hash is computed over the ingredient assertion as c2pa-rs serialises it. A hand-written reference is rejected at build time:

```
could not decode assertion c2pa.actions.v2 ... missing field `hash`
```

Supplying a `parentOf` ingredient isn't sufficient either — #9's conformance tests record that as a separate failing case.

## The way through

`BuilderIntent::Edit` derives the parent ingredient from the source file and wires the action to it. The intent **cannot** be carried in the manifest JSON — `Builder` deserialises the field but never applies it, which I confirmed before adding the native argument — so it's passed to the native sign call.

```ruby
C2PA::Manifest.new(title: "Edited photo", intent: :edit)
  .add_action(C2PA::Actions::EDITED)
  .add_action(C2PA::Actions::PUBLISHED)
```

produces:

```
state:       Valid
actions:     ["c2pa.opened", "c2pa.edited", "c2pa.published"]
opened ref:  ["url", "hash"]
ingredients: ["parentOf"]
```

`add_action` now rejects `c2pa.opened` with a message pointing at the intent, since there's no correct way to build it by hand.

## Only `:edit` is offered

c2pa-rs also has `:update`, a restricted edit for non-editorial changes. It requires an ingredient with real content, and `add_ingredient` records metadata only, so signing fails with `ingredient file not found`. Rather than ship an intent that doesn't work, `INTENTS` lists only `:edit`, and the wider ingredient gap is filed as #35.

## A note on the manifest interface

`C2PA.sign` asks for an intent only if the manifest responds to it, so an object providing just `to_json` still signs — as a creation. That keeps the duck-typed contract the conformance harness relies on.

## Verified to fail (#10 discipline)

| Mutation | Result |
|---|---|
| Intent never reaches the native layer | 4 errors |
| Rust maps `edit` to `Update` | 4 errors |
| `c2pa.opened` no longer rejected | 1 failure |
| Unknown intents accepted | 1 failure |
| *(control)* | **0 failures** |

Two of those mutate the Rust, so they prove the tests reach through the FFI boundary.

Worth recording a mistake here: my first mutation run restored `lib/c2pa.rb` with `git checkout --`, which reverted uncommitted work and left Ruby calling a 6-argument function that now takes 7. The "control" run then showed 54 errors, which is the only reason I caught it. Mutation restores now come from file backups, never from git, when the file carries uncommitted changes.

70 runs, 197 assertions, 0 failures, 0 skips.

## Verification

```
bundle exec rake test
```