### PR TITLE
Credit the gem as claim generator and fix the gemspec links

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,39 @@ result = C2PA.read(file: "photo_signed.jpg")
 
 active = result["manifests"][result["active_manifest"]]
 puts active["title"]
-puts active["claim_generator_info"].first["name"]
+puts active["claim_generator_info"].first["name"]   # => "ruby-c2pa"
 ```
+
+### Naming your application
+
+Signed files credit `ruby-c2pa` by default. To credit your own application
+instead:
+
+```ruby
+manifest = C2PA::Manifest.new(
+  title:             "Sunset over the bay",
+  generator_name:    "Acme Editor",
+  generator_version: "2.0"
+).add_action(C2PA::Actions::CREATED)
+```
+
+The signed manifest then reads:
+
+```json
+{
+  "name": "Acme Editor",
+  "version": "2.0",
+  "org.rubygems.ruby_c2pa": "0.3.0",
+  "org.contentauth.c2pa_rs": "0.78.8"
+}
+```
+
+c2pa-rs permits exactly one claim generator entry, so your application replaces
+the gem as the name rather than preceding it. The gem is recorded in a
+namespaced field alongside it, which is how c2pa-rs records itself.
+
+Releases before 0.3.0 credited `c2pa-rs` and named neither the gem nor the
+calling application.
 
 ### Checking the SDK version
 

--- a/lib/c2pa/manifest.rb
+++ b/lib/c2pa/manifest.rb
@@ -16,13 +16,21 @@ module C2PA
     # fails with "ingredient file not found". Tracked separately.
     INTENTS = %i[edit].freeze
 
+    # c2pa-rs records itself in a namespaced field alongside the generator
+    # name, so the gem does the same when an application supplies its own.
+    GEM_FIELD = "org.rubygems.ruby_c2pa".freeze
+
     # @return [Symbol, nil] the builder intent, if any
     attr_reader :intent
 
     # @param title  [String] human-readable title for this asset
-    # @param intent [Symbol, nil] :edit or :update; omit for a new creation
+    # @param intent [Symbol, nil] :edit; omit for a new creation
+    # @param generator_name    [String, nil] the application doing the signing.
+    #   Defaults to this gem. Supplying it credits your application as the
+    #   claim generator, with the gem recorded alongside.
+    # @param generator_version [String, nil] version of that application
     # @raise [C2PA::InvalidManifestError] if the intent is not recognised
-    def initialize(title:, intent: nil)
+    def initialize(title:, intent: nil, generator_name: nil, generator_version: nil)
       unless intent.nil? || INTENTS.include?(intent)
         raise InvalidManifestError,
               "unknown intent #{intent.inspect}. Valid options: #{INTENTS.map(&:inspect).join(', ')}"
@@ -30,6 +38,8 @@ module C2PA
 
       @title = title
       @intent = intent
+      @generator_name = generator_name
+      @generator_version = generator_version
       @actions = []
       @assertions = []
       @ingredients = []
@@ -106,6 +116,7 @@ module C2PA
 
       manifest = {
         "title" => @title,
+        "claim_generator_info" => [claim_generator_info],
         "assertions" => [
           { "label" => "c2pa.actions.v2", "data" => { "actions" => @actions } },
           *@assertions
@@ -123,6 +134,25 @@ module C2PA
         raise InvalidManifestError,
               "manifest contains text that cannot be encoded as JSON: #{e.message}"
       end
+    end
+
+    private
+
+    # Who signed this. Without it c2pa-rs names itself, so every asset this gem
+    # produced credited "c2pa-rs" and nothing identified the gem or the
+    # application using it.
+    #
+    # c2pa-rs 0.78 permits exactly one entry — supplying two fails with "only 1
+    # claim_generator_info allowed" — so an application name replaces the gem
+    # rather than preceding it, and the gem moves into a namespaced field. That
+    # mirrors how c2pa-rs records itself as org.contentauth.c2pa_rs.
+    def claim_generator_info
+      return { "name" => "ruby-c2pa", "version" => VERSION } if @generator_name.nil?
+
+      info = { "name" => @generator_name }
+      info["version"] = @generator_version if @generator_version
+      info[GEM_FIELD] = VERSION
+      info
     end
   end
 end

--- a/ruby-c2pa.gemspec
+++ b/ruby-c2pa.gemspec
@@ -8,8 +8,13 @@ Gem::Specification.new do |spec|
   spec.summary          = "Ruby bindings for the c2pa content authenticity library"
   spec.description      = "Embed and verify C2PA content provenance and authenticity credentials in images, video, and audio files. Ruby bindings for the official Rust c2pa-rs library."
   spec.license          = "MIT"
-  spec.homepage         = "https://github.com/carlosrodriguez/ruby-c2pa"
-  spec.metadata["source_code_uri"] = spec.homepage
+  spec.homepage         = "https://github.com/eddorre/ruby-c2pa"
+
+  spec.metadata["source_code_uri"]   = spec.homepage
+  spec.metadata["bug_tracker_uri"]   = "#{spec.homepage}/issues"
+  # changelog_uri is added in #21, when CHANGELOG.md exists. Linking to a file
+  # that is not there yet would repeat the defect this change fixes.
+  spec.metadata["documentation_uri"] = "#{spec.homepage}/blob/main/README.md"
 
   spec.files         = Dir["lib/**/*.rb", "ext/**/*.{rs,toml,rb}", "Rakefile", "*.gemspec", "LICENSE", "README.md"]
   spec.require_paths = ["lib"]

--- a/test/c2pa_test.rb
+++ b/test/c2pa_test.rb
@@ -353,8 +353,12 @@ class C2PATest < Minitest::Test
   def test_gemspec_homepage_matches_the_git_remote
     remote = `git config --get remote.origin.url 2>/dev/null`.strip
     if remote.empty?
-      # Not a git checkout, so there is nothing to compare against. The format
-      # check above still applies.
+      # No remote to compare against — a tarball, or a checkout without one.
+      # In CI there is always a remote, so a fallback there would mean this
+      # test had quietly stopped comparing anything while still reporting
+      # green. Fail rather than let that happen unnoticed.
+      flunk "no git remote found, so the homepage was never checked" if ENV["CI"]
+
       assert_match(%r{\Ahttps://}, gemspec.homepage)
       return
     end

--- a/test/c2pa_test.rb
+++ b/test/c2pa_test.rb
@@ -326,6 +326,98 @@ class C2PATest < Minitest::Test
                     "0.78.4 and can resolve atree 0.5.3, which aborts the process on TIFF input"
   end
 
+  # ─── Gem metadata ──────────────────────────────────────────────────────────
+  #
+  # Released versions pointed homepage and source_code_uri at
+  # github.com/carlosrodriguez/ruby-c2pa, which does not exist, so anyone
+  # following the link from RubyGems got a 404.
+  #
+  # Whether a URL resolves cannot be checked without a network, and a test that
+  # reaches the internet is a test that fails on a train. What is checked here
+  # is internal consistency: the links agree with each other, so updating the
+  # homepage cannot leave the others pointing somewhere else.
+
+  def gemspec
+    @gemspec ||= Gem::Specification.load(File.expand_path("../ruby-c2pa.gemspec", __dir__))
+  end
+
+  def test_gemspec_declares_a_homepage
+    refute_nil gemspec.homepage
+    assert_match(%r{\Ahttps://}, gemspec.homepage)
+  end
+
+  # The gemspec interpolates every metadata link from spec.homepage, so
+  # asserting they agree with it would be a tautology — it cannot fail. The
+  # real question is whether the homepage names the repository this code
+  # actually lives in, and git can answer that.
+  def test_gemspec_homepage_matches_the_git_remote
+    remote = `git config --get remote.origin.url 2>/dev/null`.strip
+    if remote.empty?
+      # Not a git checkout, so there is nothing to compare against. The format
+      # check above still applies.
+      assert_match(%r{\Ahttps://}, gemspec.homepage)
+      return
+    end
+
+    expected = remote.sub(%r{\A(git@|https://)}, "")
+                     .sub(":", "/")
+                     .sub(%r{\.git\z}, "")
+    assert_equal "https://#{expected}", gemspec.homepage,
+                 "the gemspec points somewhere other than this repository"
+  end
+
+  def test_gemspec_links_do_not_reference_a_missing_changelog
+    # CHANGELOG.md does not exist yet; linking to it would repeat the defect.
+    refute gemspec.metadata.key?("changelog_uri"),
+           "changelog_uri should only be declared once CHANGELOG.md exists"
+  end
+
+  # ─── Claim generator ───────────────────────────────────────────────────────
+  #
+  # Without a claim_generator_info of our own, c2pa-rs names itself, so every
+  # asset this gem signed credited "c2pa-rs" and nothing identified the gem or
+  # the application using it. The README even told callers to read that field
+  # expecting their own application name.
+
+  def test_signed_files_credit_the_gem_by_default
+    read_back(created_manifest) do |active, _|
+      info = Array(active["claim_generator_info"]).first
+      assert_equal "ruby-c2pa", info["name"]
+      assert_equal C2PA::VERSION, info["version"]
+    end
+  end
+
+  def test_an_application_can_name_itself_as_the_generator
+    manifest = C2PA::Manifest.new(title: "Test", generator_name: "Acme Editor",
+                                  generator_version: "2.0")
+                             .add_action(C2PA::Actions::CREATED)
+
+    read_back(manifest) do |active, _|
+      info = Array(active["claim_generator_info"]).first
+      assert_equal "Acme Editor", info["name"]
+      assert_equal "2.0", info["version"]
+    end
+  end
+
+  # c2pa-rs 0.78 permits exactly one entry, so the gem cannot sit alongside an
+  # application as a second entry. It goes into a namespaced field instead,
+  # which is how c2pa-rs records itself.
+  def test_the_gem_is_still_recorded_when_an_application_names_itself
+    manifest = C2PA::Manifest.new(title: "Test", generator_name: "Acme Editor")
+                             .add_action(C2PA::Actions::CREATED)
+
+    read_back(manifest) do |active, _|
+      info = Array(active["claim_generator_info"]).first
+      assert_equal C2PA::VERSION, info[C2PA::Manifest::GEM_FIELD]
+    end
+  end
+
+  def test_only_one_claim_generator_entry_is_emitted
+    json = JSON.parse(created_manifest.to_json)
+    assert_equal 1, json["claim_generator_info"].length,
+                 "c2pa-rs rejects more than one entry: only 1 claim_generator_info allowed"
+  end
+
   # ─── Editing an existing asset ─────────────────────────────────────────────
   #
   # A c2pa.opened action must reference its parent ingredient by hashed URI,


### PR DESCRIPTION
Closes #14
Closes #15

Two small defects in released versions, both user-visible.

## #14 — signed files credited c2pa-rs

The gem never set `claim_generator_info`, so the SDK filled in its own. Nothing in a signed asset identified the gem or the application that produced it — and the README told callers to read that field expecting their own application name.

| | `claim_generator_info` |
|---|---|
| Before | `{"name":"c2pa-rs","version":"0.78.8"}` |
| Now, by default | `{"name":"ruby-c2pa","version":"0.2.1",...}` |
| With an application | `{"name":"Acme Editor","version":"2.0","org.rubygems.ruby_c2pa":"0.2.1",...}` |

```ruby
C2PA::Manifest.new(title: "...", generator_name: "Acme Editor", generator_version: "2.0")
```

**c2pa-rs 0.78 permits exactly one entry** — supplying two fails with `only 1 claim_generator_info allowed` — so an application *replaces* the gem as the name rather than preceding it, and the gem moves into `org.rubygems.ruby_c2pa`. That mirrors how c2pa-rs records itself as `org.contentauth.c2pa_rs`. I established the one-entry limit by testing it, not by reading docs.

## #15 — the homepage 404s

`homepage` and `source_code_uri` pointed at `github.com/carlosrodriguez/ruby-c2pa`, which does not exist. Anyone following the link from RubyGems got a 404 — live right now, on a gem with 255 downloads.

Fixed, with bug tracker and documentation links alongside. All four verified to return **200**.

`changelog_uri` is deliberately absent until `CHANGELOG.md` exists in #21 — linking to a file that isn't there would repeat the defect being fixed — and a test asserts it stays absent until then.

## Verified to fail (#10 discipline)

| Mutation | Result |
|---|---|
| `claim_generator_info` not emitted | 3 failures, 1 error |
| Gem not recorded when an app names itself | 1 failure |
| Default reverted to `c2pa-rs` | 1 failure |
| Two entries emitted | 2 failures, 45 errors |
| Homepage points at the wrong repository | 1 failure |
| *(control)* | **0 failures** |

**One of these caught a tautology in my own test.** My first gemspec test asserted the metadata links agreed with the homepage — and mutating the homepage *didn't fail it*, because the gemspec interpolates every link from `spec.homepage`. They cannot disagree by construction, so the test could never fail.

It's replaced by one comparing the homepage against the git remote, which does catch the original defect: pointing at `carlosrodriguez/ruby-c2pa` now produces a failure.

That's the third time a mutation has caught a problem with the test rather than the code, which is roughly the point of doing it.

77 runs, 208 assertions, 0 failures, 0 skips.

## Verification

```
bundle exec rake test
```