### PR TITLE
Bump to c2pa-rs 0.90 and enforce the rules it adds

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,39 @@ Every signed file requires a `C2PA::Manifest` with at least one action. Actions 
 require "c2pa"
 
 manifest = C2PA::Manifest.new(title: "Sunset over the bay")
-manifest.add_action(C2PA::Actions::CREATED)
+manifest.add_action(
+  C2PA::Actions::CREATED,
+  digital_source_type: C2PA::DigitalSourceTypes::DIGITAL_CAPTURE
+)
 ```
+
+`c2pa.created` must declare how the asset came into being. c2pa-rs rejects a
+manifest without it, and accepts any string you supply — so a wrong value
+validates while asserting something untrue. The gem therefore requires you to
+choose rather than defaulting on your behalf:
+
+| Constant | Use for |
+|----------|---------|
+| `DIGITAL_CAPTURE` | a camera original |
+| `TRAINED_ALGORITHMIC_MEDIA` | generative AI output |
+| `COMPOSITE_WITH_TRAINED_ALGORITHMIC_MEDIA` | edited using generative AI |
+| `SCREEN_CAPTURE` | a screenshot |
+| `HUMAN_EDITS` | human-edited media |
+| `UNSPECIFIED` | the origin is genuinely unknown |
+
+`C2PA::DigitalSourceTypes::ALL` lists them all. Reach for `UNSPECIFIED` when you
+do not know — it is what c2pa-rs uses in its own fixtures, and it is honest in a
+way that guessing is not.
+
+This requirement arrived in c2pa-rs 0.90. Manifests signed by releases before
+0.3.0 omit the field and are rejected by current verifiers.
 
 Actions can be chained:
 
 ```ruby
 manifest = C2PA::Manifest.new(title: "Sunset over the bay")
-  .add_action(C2PA::Actions::CREATED)
+  .add_action(C2PA::Actions::CREATED,
+              digital_source_type: C2PA::DigitalSourceTypes::DIGITAL_CAPTURE)
   .add_action(C2PA::Actions::PUBLISHED)
 ```
 
@@ -203,7 +228,8 @@ The `output` path must not already exist — `C2PA.sign` will raise a `C2PA::Sig
 
 ```ruby
 manifest = C2PA::Manifest.new(title: "Sunset over the bay")
-  .add_action(C2PA::Actions::CREATED)
+  .add_action(C2PA::Actions::CREATED,
+              digital_source_type: C2PA::DigitalSourceTypes::DIGITAL_CAPTURE)
 
 C2PA.sign(
   file:        "photo.jpg",
@@ -269,7 +295,10 @@ manifest = C2PA::Manifest.new(
   title:             "Sunset over the bay",
   generator_name:    "Acme Editor",
   generator_version: "2.0"
-).add_action(C2PA::Actions::CREATED)
+).add_action(
+  C2PA::Actions::CREATED,
+  digital_source_type: C2PA::DigitalSourceTypes::DIGITAL_CAPTURE
+)
 ```
 
 The signed manifest then reads:

--- a/ext/c2pa_native/Cargo.lock
+++ b/ext/c2pa_native/Cargo.lock
@@ -61,56 +61,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,9 +68,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -191,9 +141,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atree"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132573478eb9ff973c6f75d0ed425ac12da77d266506483345f46743ecc83a98"
+checksum = "239d25181cb40f1955529367ee495e35d03aab4e578028f41e7abc8b21c367a8"
 
 [[package]]
 name = "autocfg"
@@ -212,6 +162,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -287,6 +243,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +270,15 @@ checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -360,15 +334,15 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "c2pa"
-version = "0.78.8"
+version = "0.90.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0c8e8f102d360112edefb3e7fc3b7651d9361e617a55c532d662bbd566fb09"
+checksum = "0de890fccb64664b95b0a1beea2bffbd95f898774ea04658ef28f3793cf58bc9"
 dependencies = [
  "asn1-rs",
  "async-generic",
  "async-trait",
  "atree",
- "base64",
+ "base64 0.22.1",
  "bcder",
  "brotli",
  "byteorder",
@@ -376,20 +350,18 @@ dependencies = [
  "bytes",
  "c2pa_cbor",
  "chrono",
- "config",
  "console_log",
  "const-hex",
- "const-oid",
+ "const-oid 0.9.6",
  "coset",
  "der",
  "ecdsa",
  "ed25519-dalek",
- "env_logger",
  "extfmt",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
+ "glob",
  "hex",
- "hex-literal",
  "http",
  "id3",
  "img-parts",
@@ -399,7 +371,6 @@ dependencies = [
  "lazy_static",
  "log",
  "memchr",
- "mp4",
  "nom",
  "non-empty-string",
  "nonempty-collections",
@@ -413,7 +384,7 @@ dependencies = [
  "pkcs8",
  "png_pong",
  "quick-xml",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rand_chacha 0.9.0",
  "range-set",
  "rasn",
@@ -432,12 +403,12 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha1",
- "sha2",
+ "sha2 0.11.0",
  "spki",
  "static-iref",
  "tempfile",
  "thiserror 2.0.18",
- "toml 1.0.6+spec-1.1.0",
+ "toml",
  "ureq",
  "url",
  "uuid",
@@ -565,25 +536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "config"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
-dependencies = [
- "nom",
- "pathdiff",
- "serde",
- "serde_json",
- "toml 0.8.23",
-]
-
-[[package]]
 name = "console_log"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,12 +548,12 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -611,6 +563,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -643,6 +601,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -685,15 +652,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -768,7 +744,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -803,10 +779,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -833,10 +820,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "spki",
 ]
@@ -861,7 +848,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "subtle",
  "zeroize",
@@ -881,7 +868,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -892,29 +879,6 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "env_filter"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -1190,12 +1154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hex-literal"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
-
-[[package]]
 name = "hex_fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,14 +1174,14 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1257,6 +1215,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1303,7 +1270,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1435,9 +1402,9 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "id3"
-version = "1.16.4"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c5e6a62a241f2f673df956ea5f52c27780bc1031855890a551ed9b869e2d1"
+checksum = "24993fcabcbc07c8ac076a8e62db8593d1a5c4dbe81d57e531d2b7cb7f737380"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -1553,12 +1520,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,10 +1556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1613,12 +1576,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.91"
+name = "jiff-tzdb"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
- "once_cell",
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1679,9 +1658,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru-slab"
@@ -1714,9 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minimal-lexical"
@@ -1753,20 +1732,6 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "mp4"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ef834d5ed55e494a2ae350220314dc4aacd1c43a9498b00e320e0ea352a5c3"
-dependencies = [
- "byteorder",
- "bytes",
- "num-rational",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1819,7 +1784,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "smallvec",
  "zeroize",
@@ -1852,18 +1817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,22 +1842,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1931,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -1951,7 +1897,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1963,7 +1909,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1977,7 +1923,7 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1988,12 +1934,6 @@ checksum = "9c695d2b8bcf1dd62a5173a9c43e6ebbe9261701c002f9b462fc9690c144bb61"
 dependencies = [
  "traitful",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pct-str"
@@ -2011,7 +1951,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2196,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -2287,9 +2227,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2371,9 +2311,9 @@ checksum = "d20581732dd76fa913c7dff1a2412b714afe3573e94d41c34719de73337cc8ab"
 
 [[package]]
 name = "rasn"
-version = "0.28.10"
+version = "0.28.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891614cb7ad883e74f7ccc47472b49d1bb50150e3d1cc62ed78a3f0665d8985e"
+checksum = "0d1b71dd951343df0fe30b11bca09518f3aba8e5bd0ece4564adbc2dabd875fa"
 dependencies = [
  "bitvec",
  "bitvec-nom2",
@@ -2394,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "rasn-cms"
-version = "0.28.10"
+version = "0.28.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b94e9087fd91435e1494e10f28bffe9ea3a38f514711138e686b9ef3dbff26e"
+checksum = "7b4abf4c2fe5537b99e2bf3099a7ad26e40bd9cf51bc003600ed58dbbff69a1c"
 dependencies = [
  "rasn",
  "rasn-pkix",
@@ -2429,9 +2369,9 @@ dependencies = [
 
 [[package]]
 name = "rasn-ocsp"
-version = "0.28.10"
+version = "0.28.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cdc767c7ad9bb24b5eb4c4a8ee6a3160f73f48e72ca6a9b1f5860d3c7a20ee9"
+checksum = "f8bf6709bc94437d12614fd2d34463c3478d981bf913286812cc50bb093bc657"
 dependencies = [
  "rasn",
  "rasn-pkix",
@@ -2439,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "rasn-pkix"
-version = "0.28.10"
+version = "0.28.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d605209c02f614485e3b3d7048045a92b8dbfdafb175a2dc085332b0d0b5a5b"
+checksum = "c029da7ed3b94dd93b75299431984081c1eaf88ce79771c21b056f0ebf6fb964"
 dependencies = [
  "rasn",
 ]
@@ -2531,7 +2471,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "h2",
@@ -2600,15 +2540,15 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
@@ -2818,9 +2758,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",
@@ -2832,18 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -2862,15 +2793,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
- "base64",
+ "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.13.0",
+ "jiff",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -2881,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2893,13 +2826,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2909,18 +2842,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
- "sha2-asm",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "sha2-asm"
-version = "0.6.4"
+name = "sha2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
- "cc",
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2941,7 +2875,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3042,7 +2976,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "thiserror 1.0.69",
 ]
@@ -3276,26 +3210,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
-version = "1.0.6+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.0.4",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -3303,56 +3225,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.13.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow",
-]
-
-[[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3443,9 +3336,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -3473,27 +3366,27 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "log",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-roots",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "http",
  "httparse",
  "log",
@@ -3512,16 +3405,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8-decode"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3530,16 +3423,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3603,9 +3490,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3616,23 +3503,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3640,9 +3523,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3653,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -3696,9 +3579,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3951,12 +3834,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"
@@ -4231,9 +4111,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.2.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b680f2a0cd479b4cff6e1233c483fdead418106eae419dc60200ae9850f6d004"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "indexmap 2.13.0",

--- a/ext/c2pa_native/Cargo.toml
+++ b/ext/c2pa_native/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 magnus = { version = "0.8", features = [] }
-c2pa = { version = "0.78", features = ["file_io"] }
+c2pa = { version = "0.90", features = ["file_io"] }
 serde_json = "1"
 
 [profile.release]

--- a/lib/c2pa.rb
+++ b/lib/c2pa.rb
@@ -2,6 +2,7 @@ require "json"
 require_relative "c2pa/version"
 require_relative "c2pa/error"
 require_relative "c2pa/actions"
+require_relative "c2pa/digital_source_types"
 require_relative "c2pa/manifest"
 require "c2pa/c2pa_native"
 

--- a/lib/c2pa/digital_source_types.rb
+++ b/lib/c2pa/digital_source_types.rb
@@ -1,0 +1,72 @@
+module C2PA
+  # URIs from the IPTC Digital Source Type NewsCodes vocabulary.
+  #
+  # The C2PA specification requires every c2pa.created action to declare one of
+  # these, so consumers can tell how the asset came into being. Pick the one that
+  # honestly describes the asset — this is a provenance claim, and c2pa-rs will
+  # not second-guess the value you supply.
+  #
+  # @see https://cv.iptc.org/newscodes/digitalsourcetype/
+  module DigitalSourceTypes
+    BASE = "http://cv.iptc.org/newscodes/digitalsourcetype"
+
+    # Declining to claim a source type, rather than guessing at one.
+    #
+    # c2pa-rs requires c2pa.created to carry a digitalSourceType but accepts
+    # any string, so a wrong value validates silently. When the origin is not
+    # known — a generic signing service, say — this says so, instead of
+    # asserting something untrue. It is the value c2pa-rs uses throughout its
+    # own fixtures.
+    UNSPECIFIED = "http://c2pa.org/digitalsourcetype/empty"
+
+    # Captured from real life
+    DIGITAL_CAPTURE       = "#{BASE}/digitalCapture"
+    COMPUTATIONAL_CAPTURE = "#{BASE}/computationalCapture"
+    SCREEN_CAPTURE        = "#{BASE}/screenCapture"
+    VIRTUAL_RECORDING     = "#{BASE}/virtualRecording"
+
+    # Digitised from a physical medium
+    NEGATIVE_FILM = "#{BASE}/negativeFilm"
+    POSITIVE_FILM = "#{BASE}/positiveFilm"
+    PRINT         = "#{BASE}/print"
+
+    # Human- or software-authored
+    HUMAN_EDITS              = "#{BASE}/humanEdits"
+    DIGITAL_CREATION         = "#{BASE}/digitalCreation"
+    ALGORITHMICALLY_ENHANCED = "#{BASE}/algorithmicallyEnhanced"
+    DATA_DRIVEN_MEDIA        = "#{BASE}/dataDrivenMedia"
+    ALGORITHMIC_MEDIA        = "#{BASE}/algorithmicMedia"
+
+    # Generative AI
+    TRAINED_ALGORITHMIC_MEDIA                = "#{BASE}/trainedAlgorithmicMedia"
+    COMPOSITE_WITH_TRAINED_ALGORITHMIC_MEDIA = "#{BASE}/compositeWithTrainedAlgorithmicMedia"
+    COMPOSITE_SYNTHETIC                      = "#{BASE}/compositeSynthetic"
+
+    # Composites
+    COMPOSITE         = "#{BASE}/composite"
+    COMPOSITE_CAPTURE = "#{BASE}/compositeCapture"
+
+    # Every type defined above. Supplying a URI outside this list is allowed —
+    # the vocabulary is extensible — but the values here cover the standard set.
+    ALL = [
+      UNSPECIFIED,
+      DIGITAL_CAPTURE,
+      COMPUTATIONAL_CAPTURE,
+      SCREEN_CAPTURE,
+      VIRTUAL_RECORDING,
+      NEGATIVE_FILM,
+      POSITIVE_FILM,
+      PRINT,
+      HUMAN_EDITS,
+      DIGITAL_CREATION,
+      ALGORITHMICALLY_ENHANCED,
+      DATA_DRIVEN_MEDIA,
+      ALGORITHMIC_MEDIA,
+      TRAINED_ALGORITHMIC_MEDIA,
+      COMPOSITE_WITH_TRAINED_ALGORITHMIC_MEDIA,
+      COMPOSITE_SYNTHETIC,
+      COMPOSITE,
+      COMPOSITE_CAPTURE
+    ].freeze
+  end
+end

--- a/lib/c2pa/manifest.rb
+++ b/lib/c2pa/manifest.rb
@@ -69,6 +69,30 @@ module C2PA
               "intent: :edit to C2PA::Manifest.new instead and the action will be added for you."
       end
 
+      # Required as of c2pa-rs 0.90. Earlier versions accepted its absence, so
+      # manifests signed by releases before 0.3.0 are rejected by current
+      # verifiers. No default is supplied: c2pa-rs accepts any string here, so
+      # a guess would validate while asserting something untrue about where the
+      # asset came from. Use DigitalSourceTypes::UNSPECIFIED to decline.
+      if action == Actions::CREATED && to_s_or_nil(digital_source_type).nil?
+        raise InvalidManifestError,
+              "#{Actions::CREATED} requires a digital_source_type. Choose the value that " \
+              "describes how the asset was produced — for example " \
+              "C2PA::DigitalSourceTypes::DIGITAL_CAPTURE for a camera original, or " \
+              "TRAINED_ALGORITHMIC_MEDIA for generative AI. If the origin is genuinely " \
+              "unknown, use C2PA::DigitalSourceTypes::UNSPECIFIED rather than guessing."
+      end
+
+      # Also new in c2pa-rs 0.90.
+      if action == Actions::TRANSLATED
+        missing = %w[sourceLanguage targetLanguage].reject { |key| param_present?(parameters, key) }
+        unless missing.empty?
+          raise InvalidManifestError,
+                "#{Actions::TRANSLATED} requires #{missing.join(' and ')} in parameters, " \
+                "as RFC 5646 language codes"
+        end
+      end
+
       entry = { "action" => action }
       entry["when"]              = when_time                              if when_time
       entry["softwareAgent"]     = software_agent || "ruby-c2pa/#{VERSION}"
@@ -137,6 +161,20 @@ module C2PA
     end
 
     private
+
+    # Parameters may be keyed with strings or symbols depending on the caller.
+    def param_present?(parameters, key)
+      return false unless parameters.is_a?(Hash)
+
+      !to_s_or_nil(parameters[key] || parameters[key.to_sym]).nil?
+    end
+
+    def to_s_or_nil(value)
+      return nil if value.nil?
+
+      string = value.to_s
+      string.empty? ? nil : string
+    end
 
     # Who signed this. Without it c2pa-rs names itself, so every asset this gem
     # produced credited "c2pa-rs" and nothing identified the gem or the

--- a/test/c2pa_test.rb
+++ b/test/c2pa_test.rb
@@ -44,8 +44,11 @@ class C2PATest < Minitest::Test
     FileUtils.remove_entry(dir) if dir && File.exist?(dir)
   end
 
+  DIGITAL_CAPTURE = C2PA::DigitalSourceTypes::DIGITAL_CAPTURE
+
   def created_manifest(title: "Test")
-    C2PA::Manifest.new(title: title).add_action(C2PA::Actions::CREATED)
+    C2PA::Manifest.new(title: title)
+                  .add_action(C2PA::Actions::CREATED, digital_source_type: DIGITAL_CAPTURE)
   end
 
   # Sign a fixture and yield the active manifest exactly as c2pa-rs reads it
@@ -78,7 +81,7 @@ class C2PATest < Minitest::Test
   end
 
   def test_sign_raises_on_missing_file
-    manifest = C2PA::Manifest.new(title: "Test").add_action(C2PA::Actions::CREATED)
+    manifest = C2PA::Manifest.new(title: "Test").add_action(C2PA::Actions::CREATED, digital_source_type: DIGITAL_CAPTURE)
 
     assert_raises(C2PA::SigningError) do
       C2PA.sign(
@@ -394,7 +397,7 @@ class C2PATest < Minitest::Test
   def test_an_application_can_name_itself_as_the_generator
     manifest = C2PA::Manifest.new(title: "Test", generator_name: "Acme Editor",
                                   generator_version: "2.0")
-                             .add_action(C2PA::Actions::CREATED)
+                             .add_action(C2PA::Actions::CREATED, digital_source_type: DIGITAL_CAPTURE)
 
     read_back(manifest) do |active, _|
       info = Array(active["claim_generator_info"]).first
@@ -408,7 +411,7 @@ class C2PATest < Minitest::Test
   # which is how c2pa-rs records itself.
   def test_the_gem_is_still_recorded_when_an_application_names_itself
     manifest = C2PA::Manifest.new(title: "Test", generator_name: "Acme Editor")
-                             .add_action(C2PA::Actions::CREATED)
+                             .add_action(C2PA::Actions::CREATED, digital_source_type: DIGITAL_CAPTURE)
 
     read_back(manifest) do |active, _|
       info = Array(active["claim_generator_info"]).first
@@ -596,7 +599,13 @@ class C2PATest < Minitest::Test
   # at the wrong time. They arrive with the upgrade, in #18 and #19.
 
   ACTIONS_LABEL = "c2pa.actions.v2".freeze
-  CREATED_ACTION = { "action" => "c2pa.created" }.freeze
+  # A c2pa.created without a digitalSourceType is malformed on 0.90, so using a
+  # bare one here would report assertion.action.malformed for every case and
+  # hide the rule actually being tested.
+  CREATED_ACTION = {
+    "action" => "c2pa.created",
+    "digitalSourceType" => C2PA::DigitalSourceTypes::DIGITAL_CAPTURE
+  }.freeze
   PARENT_INGREDIENT = {
     "title" => "original.jpg", "format" => "image/jpeg",
     "instance_id" => "xmp:iid:original", "relationship" => "parentOf"
@@ -703,17 +712,55 @@ class C2PATest < Minitest::Test
                  "upstream now validates action names; C2PA::Actions could be checked against it"
   end
 
-  # Introduced in c2pa-rs 0.90. Asserting the 0.90 behaviour here would fail
-  # against 0.78 for the right reason at the wrong time, so these record the
-  # current state and will flip when #16 lands.
-  def test_digital_source_type_is_not_yet_required
-    assert_empty failure_codes_for([CREATED_ACTION]),
-                 "c2pa-rs now requires digitalSourceType on c2pa.created — see #18"
+  # These two arrived with c2pa-rs 0.90. Until the bump they were recorded as
+  # not-yet-enforced; the canaries fired on upgrade, which is what they were
+  # for. They are now asserted as real rules.
+  def test_created_without_a_digital_source_type_is_rejected
+    assert_includes failure_codes_for([{ "action" => "c2pa.created" }]),
+                    "assertion.action.malformed"
   end
 
-  def test_translated_languages_are_not_yet_required
-    assert_empty failure_codes_for([CREATED_ACTION, { "action" => "c2pa.translated" }]),
-                 "c2pa-rs now requires language parameters on c2pa.translated — see #19"
+  def test_translated_without_languages_is_rejected
+    assert_includes failure_codes_for([CREATED_ACTION, { "action" => "c2pa.translated" }]),
+                    "assertion.action.malformed"
+  end
+
+  # The other half: what the builder demands must actually satisfy c2pa-rs.
+  def test_translated_with_languages_signs_clean
+    manifest = created_manifest.add_action(
+      C2PA::Actions::TRANSLATED,
+      parameters: { "sourceLanguage" => "en-US", "targetLanguage" => "fr-FR" }
+    )
+
+    read_back(manifest) do |_, result|
+      assert_includes C2PA::VALID_STATES, result["validation_state"]
+    end
+  end
+
+  # Builder-side enforcement, so the failure arrives at the call site rather
+  # than after signing.
+  def test_builder_requires_a_digital_source_type_for_created
+    error = assert_raises(C2PA::InvalidManifestError) do
+      C2PA::Manifest.new(title: "Test").add_action(C2PA::Actions::CREATED)
+    end
+    assert_match(/digital_source_type/, error.message)
+    assert_match(/UNSPECIFIED/, error.message, "the error should offer an honest opt-out")
+  end
+
+  def test_builder_requires_languages_for_translated
+    assert_raises(C2PA::InvalidManifestError) do
+      created_manifest.add_action(C2PA::Actions::TRANSLATED)
+    end
+  end
+
+  def test_unspecified_source_type_is_accepted
+    manifest = C2PA::Manifest.new(title: "Test")
+                             .add_action(C2PA::Actions::CREATED,
+                                         digital_source_type: C2PA::DigitalSourceTypes::UNSPECIFIED)
+
+    read_back(manifest) do |_, result|
+      assert_includes C2PA::VALID_STATES, result["validation_state"]
+    end
   end
 
   # ─── Character and encoding handling ───────────────────────────────────────
@@ -789,7 +836,7 @@ class C2PATest < Minitest::Test
   # sufficient. See #28.
   def test_invalid_utf8_raises_a_c2pa_error
     title = (+"bad").concat(255.chr).concat("byte")
-    manifest = C2PA::Manifest.new(title: title).add_action(C2PA::Actions::CREATED)
+    manifest = C2PA::Manifest.new(title: title).add_action(C2PA::Actions::CREATED, digital_source_type: DIGITAL_CAPTURE)
 
     error = assert_raises(C2PA::InvalidManifestError) { manifest.to_json }
     assert_kind_of C2PA::Error, error, "callers rescue C2PA::Error and must catch this"
@@ -823,7 +870,7 @@ class C2PATest < Minitest::Test
 
   def test_custom_software_agent_survives_signing
     manifest = C2PA::Manifest.new(title: "Test")
-                             .add_action(C2PA::Actions::CREATED,
+                             .add_action(C2PA::Actions::CREATED, digital_source_type: DIGITAL_CAPTURE,
                                          software_agent: "Acme Editor/2.0")
 
     read_back(manifest) do |active, _|
@@ -833,7 +880,7 @@ class C2PATest < Minitest::Test
 
   def test_when_time_survives_signing
     manifest = C2PA::Manifest.new(title: "Test")
-                             .add_action(C2PA::Actions::CREATED,
+                             .add_action(C2PA::Actions::CREATED, digital_source_type: DIGITAL_CAPTURE,
                                          when_time: "2026-03-17T10:00:00Z")
 
     read_back(manifest) do |active, _|
@@ -845,7 +892,7 @@ class C2PATest < Minitest::Test
   def test_digital_source_type_survives_signing
     source_type = "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCapture"
     manifest = C2PA::Manifest.new(title: "Test")
-                             .add_action(C2PA::Actions::CREATED,
+                             .add_action(C2PA::Actions::CREATED, digital_source_type: DIGITAL_CAPTURE,
                                          digital_source_type: source_type)
 
     read_back(manifest) do |active, _|


### PR DESCRIPTION
Closes #16
Closes #18
Closes #19
Closes #20

The extension compiles unchanged against 0.90.15. Two validation rules arrive with it, and sprint 1 recorded in advance that they were not yet enforced. **Those canaries fired on the upgrade**, carrying the messages written for this moment:

```
c2pa-rs now requires digitalSourceType on c2pa.created — see #18
c2pa-rs now requires language parameters on c2pa.translated — see #19
```

That is the whole point of #30 — the upgrade told us what it changed, instead of us finding out from a user.

## The two new rules

Both are enforced by the builder, so the failure lands at the call site rather than after signing, and both are pinned to c2pa-rs's verdict by conformance tests.

**No default source type is supplied.** c2pa-rs accepts any string, so a guess validates while asserting something untrue — a camera original and generative AI output are not interchangeable claims. `DigitalSourceTypes::UNSPECIFIED` covers a genuinely unknown origin; it is the value c2pa-rs uses in its own fixtures, and the error message points at it.

## A confound worth naming

The conformance harness's known-good action was a bare `c2pa.created` — which is *itself* malformed on 0.90. Left alone it would have reported `assertion.action.malformed` for every case and masked the rule each one was meant to test. Three canaries appeared to fire when only one had. It now carries a source type.

## Two canaries did not fire

Recorded as still-unenforced, unchanged from 0.78:

- a repeated `created` is not flagged — the check compares the actions-assertion index rather than the action index
- action names are still unvalidated, so `C2PA::Actions` still has no external oracle

## #20: matrices re-verified on 0.90

Ten formats — JPEG, PNG, WebP, TIFF, AVIF, JPEG XL, WAV, MP3, MP4, MOV — and seven algorithms, all signing and validating. Nothing regressed.

The README examples were **executed rather than eyeballed**: 8 run clean, 6 skipped as needing real files.

## Verified to fail (#10 discipline)

| Mutation | Result |
|---|---|
| `created` no longer requires a source type | 1 failure |
| `translated` no longer requires languages | 1 failure |
| Source type not emitted into the manifest | 43 errors |
| `UNSPECIFIED` blanked to an empty string | 1 error |
| *(control)* | **0 failures** |

**81 runs, 218 assertions, 0 failures, 0 skips — on c2pa-rs 0.90.15.**

## Breaking change

`add_action(CREATED)` now raises without a `digital_source_type`. Manifests signed by releases before 0.3.0 omit the field and are rejected by current verifiers — which belongs in the CHANGELOG (#21) with re-signing guidance.

## Verification

```
bundle exec rake test
```