### PR TITLE
Stop packaging Rust build artifacts, and ship the lockfile

### DIFF
--- a/ruby-c2pa.gemspec
+++ b/ruby-c2pa.gemspec
@@ -16,7 +16,27 @@ Gem::Specification.new do |spec|
   # that is not there yet would repeat the defect this change fixes.
   spec.metadata["documentation_uri"] = "#{spec.homepage}/blob/main/README.md"
 
-  spec.files         = Dir["lib/**/*.rb", "ext/**/*.{rs,toml,rb}", "Rakefile", "*.gemspec", "LICENSE", "README.md"]
+  # Listed explicitly rather than globbed. "ext/**/*.rs" swept in whatever
+  # happened to be under ext/c2pa_native/target, so the package contents
+  # depended on what had been compiled on the machine that ran `gem build` —
+  # 1.3 MB of dependency build-script output shipped in 0.2.1.
+  #
+  # Cargo.lock is included deliberately. The extension is compiled at install
+  # time, so without it every installer resolves the dependency tree afresh.
+  # That is how 0.2.1 shipped against a broken atree and aborted the Ruby
+  # process on TIFF input.
+  spec.files = [
+    "LICENSE",
+    "README.md",
+    "CONTRIBUTING.md",
+    "Rakefile",
+    "ruby-c2pa.gemspec",
+    "ext/c2pa_native/Cargo.toml",
+    "ext/c2pa_native/Cargo.lock",
+    "ext/c2pa_native/extconf.rb",
+    *Dir["ext/c2pa_native/src/**/*.rs"],
+    *Dir["lib/**/*.rb"]
+  ].sort
   spec.require_paths = ["lib"]
   spec.extensions    = ["ext/c2pa_native/extconf.rb"]
 

--- a/test/c2pa_test.rb
+++ b/test/c2pa_test.rb
@@ -379,6 +379,41 @@ class C2PATest < Minitest::Test
            "changelog_uri should only be declared once CHANGELOG.md exists"
   end
 
+  # ─── Packaging ─────────────────────────────────────────────────────────────
+  #
+  # 0.2.1 shipped 1.3 MB of Rust build-script output, because "ext/**/*.rs"
+  # matched everything under ext/c2pa_native/target. The package contents
+  # therefore depended on what had been compiled on the machine that ran
+  # gem build.
+
+  def test_the_gem_ships_no_build_artifacts
+    artifacts = gemspec.files.select { |f| f.include?("/target/") }
+    assert_empty artifacts, "build output must not be packaged"
+  end
+
+  def test_the_gem_ships_its_library_and_extension_sources
+    %w[
+      lib/c2pa.rb lib/c2pa/manifest.rb lib/c2pa/actions.rb
+      lib/c2pa/digital_source_types.rb lib/c2pa/error.rb lib/c2pa/version.rb
+      ext/c2pa_native/src/lib.rs ext/c2pa_native/Cargo.toml
+      ext/c2pa_native/extconf.rb
+    ].each do |path|
+      assert_includes gemspec.files, path, "#{path} is missing from the package"
+    end
+  end
+
+  # The extension is compiled at install time, so without a lockfile every
+  # installer resolves the dependency tree afresh. That is how 0.2.1 shipped
+  # against a broken atree and aborted the Ruby process on TIFF input.
+  def test_the_gem_ships_a_lockfile_so_installs_are_reproducible
+    assert_includes gemspec.files, "ext/c2pa_native/Cargo.lock"
+  end
+
+  def test_packaged_files_all_exist
+    missing = gemspec.files.reject { |f| File.exist?(File.expand_path("../#{f}", __dir__)) }
+    assert_empty missing, "packaged files that are not on disk"
+  end
+
   # ─── Claim generator ───────────────────────────────────────────────────────
   #
   # Without a claim_generator_info of our own, c2pa-rs names itself, so every


### PR DESCRIPTION
Closes #32

`spec.files` globbed `ext/**/*.rs`, which matched everything under `ext/c2pa_native/target`. The published 0.2.1 carries nine files of dependency build-script output — 1.3 MB uncompressed — and the package contents depended on whatever had been compiled on the machine that ran `gem build`.

| | Before | After |
|---|---|---|
| Packaged size | 79 KB | **48 KB** |
| `target/` entries | 9 | **0** |
| Reproducible across builds | no | **yes** |

Files are now listed explicitly. A build with a populated 784 MB `target/` produces byte-identical contents to one without.

## The lockfile was never shipped

This is the part that matters more than the size. `spec.files` covered `.rs`, `.toml` and `.rb` — and a lockfile is none of those, so `Cargo.lock` has never been in the gem.

The extension compiles at **install time**, so without a lockfile every installer resolves the dependency tree afresh. That is precisely how 0.2.1 shipped against a broken `atree` and aborted the Ruby process on TIFF input: the pin existed in the repository and never reached anyone installing the gem.

Shipping it means an install gets the dependency set that was actually tested.

## Verified by installing it

Not just inspected — the built package was installed into a clean prefix, the extension compiled, and signing a fixture with the installed gem returned:

```
gem version:  0.2.1
c2pa-rs:      0.90.15
signed state: Valid
generator:    ruby-c2pa
```

## Verified to fail (#10 discipline)

| Mutation | Result |
|---|---|
| Glob widened back to `ext/**/*.rs` | 1 failure |
| Lockfile no longer shipped | 1 failure |
| Nested `lib/` files dropped | 1 failure |
| *(control)* | **0 failures** |

85 runs, 242 assertions, 0 failures, 0 skips.

## Verification

```
gem build ruby-c2pa.gemspec
tar -xOf ruby-c2pa-*.gem data.tar.gz | tar -tz | grep -c target/   # expect 0
```