### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] — unreleased
+## [0.3.0] — 2026-08-25
 
 Runs on c2pa-rs 0.90, and fixes every defect found while building a test suite
 that verifies against c2pa-rs rather than against itself.

--- a/lib/c2pa/version.rb
+++ b/lib/c2pa/version.rb
@@ -1,3 +1,3 @@
 module C2PA
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Refs #22

Version bump and changelog date. The tag and GitHub release follow once this merges, so `v0.3.0` points at the commit that actually carries `VERSION = "0.3.0"` — tag and published gem then agree.

Breaking changes make this 0.3.0 rather than 0.2.2:

- `c2pa.created` requires a `digital_source_type`
- `C2PA.sign` raises when its output does not validate
- `c2pa.opened` must go through `intent: :edit`

## Verified by installing it, not inspecting it

```
Successfully installed ruby-c2pa-0.3.0
installed gem: 0.3.0 on c2pa-rs 0.90.15
sign+read:     Valid, generator ruby-c2pa
```

Built package installed into a clean prefix, extension compiled from source, fixture signed and read back.

85 runs, 247 assertions, 0 failures, 0 skips.