### PR TITLE
Migrate to the Context API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,21 @@ jobs:
       - name: Compile the native extension
         run: bundle exec rake compile
 
+      - name: Check for deprecated c2pa-rs API use
+        # The older Builder and Reader entry points read settings from
+        # thread-local state and are deprecated; 0.88 already removed one batch
+        # of long-deprecated APIs. Catching a reintroduction here is cheaper
+        # than discovering it when a future bump drops them.
+        run: |
+          cd ext/c2pa_native
+          count=$(cargo build --message-format=short 2>&1 | grep -c "use of deprecated" || true)
+          if [ "$count" -ne 0 ]; then
+            echo "::error::$count deprecated c2pa-rs API use(s); see CONTRIBUTING.md"
+            cargo build --message-format=short 2>&1 | grep "use of deprecated" || true
+            exit 1
+          fi
+          echo "no deprecated API use"
+
       - name: Report the c2pa-rs version under test
         # Block scalar, and no Ruby string interpolation: in a plain YAML
         # scalar " #" opens a comment, which silently truncates the command.

--- a/ext/c2pa_native/src/lib.rs
+++ b/ext/c2pa_native/src/lib.rs
@@ -1,8 +1,26 @@
 use std::path::Path;
-use c2pa::{create_signer, Builder, BuilderIntent, Reader, SigningAlg};
+use std::sync::{Arc, OnceLock};
+use c2pa::{create_signer, Builder, BuilderIntent, Context, Reader, SigningAlg};
 use magnus::{function, prelude::*, Error, Ruby};
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// A Context carries the settings c2pa-rs validates against — trust anchors,
+// what to verify, whether to fetch remote manifests. The older entry points
+// read those from thread-local state, which is why they are deprecated: a
+// threaded Ruby application could see different settings depending on which
+// thread it signed from.
+//
+// One shared Context is built lazily and reused. It is Send + Sync, so an Arc
+// is all that sharing requires, and reusing it avoids re-reading configuration
+// on every call.
+//
+// It currently carries defaults. Exposing settings to Ruby is a separate piece
+// of work; this is the seam that makes it possible.
+fn shared_context() -> &'static Arc<Context> {
+    static CONTEXT: OnceLock<Arc<Context>> = OnceLock::new();
+    CONTEXT.get_or_init(|| Context::new().into_shared())
+}
 
 fn alg_from_str(alg: &str) -> Result<SigningAlg, String> {
     match alg.to_lowercase().as_str() {
@@ -64,7 +82,8 @@ fn do_sign_file(
     let default_json = format!(r#"{{"title": "{}"}}"#, title);
     let json = manifest_json.unwrap_or(&default_json);
 
-    let mut builder = Builder::from_json(json)
+    let mut builder = Builder::from_shared_context(shared_context())
+        .with_definition(json)
         .map_err(|e| format!("Invalid manifest JSON: {}", e))?;
 
     if let Some(intent) = intent_str {
@@ -78,7 +97,8 @@ fn do_sign_file(
 }
 
 fn do_read_file(path: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let reader = Reader::from_file(path)
+    let reader = Reader::from_shared_context(shared_context())
+        .with_file(path)
         .map_err(|e| format!("Failed to read manifest from '{}': {}", path, e))?;
     Ok(reader.json())
 }

--- a/test/c2pa_test.rb
+++ b/test/c2pa_test.rb
@@ -387,6 +387,58 @@ class C2PATest < Minitest::Test
     end
   end
 
+  # Trust verification must be on. c2pa-rs checks it by default, but the native
+  # layer now supplies a Context, and a Context can turn it off — silently, in a
+  # library whose purpose is establishing trust.
+  #
+  # The development certificates chain to a root nobody trusts, so a run with
+  # trust checking enabled reports signingCredential.untrusted. If that status
+  # disappears, trust is no longer being checked at all.
+  def test_trust_verification_is_enabled
+    read_back(created_manifest) do |_, result|
+      codes = Array(result.dig("validation_results", "activeManifest", "failure"))
+              .map { |failure| failure["code"] }
+      assert_includes codes, "signingCredential.untrusted",
+                      "the development certificates are untrusted, so this status must " \
+                      "appear — its absence means trust checking is disabled"
+    end
+  end
+
+  # ─── Concurrency ───────────────────────────────────────────────────────────
+  #
+  # The native layer shares one c2pa-rs Context across calls. The entry points
+  # it replaced read their settings from thread-local state, which is the
+  # reason upstream deprecated them: a threaded application could see different
+  # settings depending on which thread it signed from.
+  #
+  # Signing from several threads at once must produce correct, unmixed results.
+
+  def test_signing_concurrently_produces_correct_results
+    assert_certificates_present
+    dir = Dir.mktmpdir
+
+    results = 8.times.map do |i|
+      Thread.new do
+        output = File.join(dir, "concurrent-#{i}.jpg")
+        manifest = C2PA::Manifest.new(title: "thread #{i}")
+                                 .add_action(C2PA::Actions::CREATED,
+                                             digital_source_type: DIGITAL_CAPTURE)
+        C2PA.sign(file: File.join(FIXTURES, "tiny.jpg"), output: output,
+                  certificate: CERT, key: KEY, manifest: manifest)
+        result = C2PA.read(file: output)
+        [result["validation_state"],
+         result["manifests"].fetch(result["active_manifest"])["title"]]
+      end
+    end.map(&:value)
+
+    states, titles = results.transpose
+    states.each { |state| assert_includes C2PA::VALID_STATES, state }
+    assert_equal (0...8).map { |i| "thread #{i}" }.sort, titles.sort,
+                 "titles were mixed between threads"
+  ensure
+    FileUtils.remove_entry(dir) if dir && File.exist?(dir)
+  end
+
   # ─── Packaging ─────────────────────────────────────────────────────────────
   #
   # 0.2.1 shipped 1.3 MB of Rust build-script output, because "ext/**/*.rs"


### PR DESCRIPTION
Closes #17

`Builder::from_json` and `Reader::from_file` are deprecated because they read settings from **thread-local state** — a threaded application could see different settings depending on which thread it signed from. c2pa-rs 0.88 already removed one batch of long-deprecated APIs, so these will follow. Doing this now is cheaper than doing it under a bump that drops them.

One `Context` is built lazily and shared. It is `Send + Sync`, so an `Arc` is all sharing needs, and reusing it avoids re-reading configuration on every call.

## Thread safety is the stated reason, so it's tested

Eight threads signing concurrently, all `Valid`, no cross-talk between titles. That's the property the deprecated API couldn't guarantee, so asserting it seemed more useful than taking the deprecation notice at its word.

## A mutation found a real blind spot

Configuring the Context to **skip trust verification** changed nothing the suite could observe — signed files are `Valid` either way; only the `signingCredential.untrusted` status differs, and nothing asserted on it.

Trust checking could have been switched off silently, in a library whose entire purpose is establishing trust. There is now a test asserting the development certificates report `signingCredential.untrusted` — its absence means trust is not being checked. With that in place, the mutation fails.

That's the fourth time a mutation has found a gap in the tests rather than a bug in the code.

## CI guards the deprecation

A new step fails the build if deprecated c2pa-rs APIs reappear. Verified by reintroducing `Reader::from_file`:

```
with a deprecated call reintroduced: 1 warning(s) -> guard would exit 1
restored:                            0 warning(s) -> guard passes
```

## Groundwork for #34

The Context is exactly where trust anchors and verification settings live. It currently holds defaults, but the seam now exists — #34 becomes wiring rather than restructuring.

## Verified to fail (#10 discipline)

| Mutation | Result |
|---|---|
| Manifest definition ignored | 10 failures, 44 errors |
| Trust checks disabled in the Context | 1 failure *(after adding the test above)* |
| Deprecated API reintroduced | CI guard exits 1 |
| *(control)* | **0 failures** |

87 runs, 266 assertions, 0 failures, 0 skips. Zero deprecation warnings.