### PR TITLE
Let callers configure trust anchors and verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,22 +64,44 @@ The native Rust library is compiled automatically during installation. This take
 
 ## Preparing your certificate and key
 
-C2PA signing requires an X.509 certificate chain and private key in PEM format. The certificate must chain to a CA that is trusted by the C2PA ecosystem — **self-signed certificates are rejected by c2pa-rs**.
+C2PA signing requires an X.509 certificate chain and private key in PEM format.
+The certificate file contains the end-entity certificate first, then any
+intermediates, and must **not** include the root.
+
+c2pa-rs enforces a certificate profile. An end-entity certificate is rejected
+unless it carries all of:
+
+- Basic Constraints `CA:FALSE`, critical
+- Key Usage with `digitalSignature` or `nonRepudiation`, critical
+- an Extended Key Usage that is present and not `any`, critical
+- a Subject Key Identifier
+- an **Authority Key Identifier**
+
+The last one is easy to miss — `openssl x509 -req` omits it by default, and the
+certificate is then rejected with nothing more specific than
+`the certificate is invalid`.
+
+### Whose CA?
+
+A certificate from a CA in the C2PA trust list validates as `Trusted` with no
+configuration.
+
+A certificate from your own CA validates as `Valid` and carries
+`signingCredential.untrusted` — which does **not** make the manifest invalid.
+To have it treated as trusted, add your root as a trust anchor; see
+[Configuring trust](#configuring-trust).
 
 ### Development and testing
 
-The c2pa-rs project publishes test certificates that work for local development:
+The test suite generates its own certificates for every supported algorithm:
 
 ```bash
-curl -sL -o test_cert.pem https://raw.githubusercontent.com/contentauth/c2pa-rs/main/sdk/tests/fixtures/certs/es256.pub
-curl -sL -o test_key.pem  https://raw.githubusercontent.com/contentauth/c2pa-rs/main/sdk/tests/fixtures/certs/es256.pem
+bundle exec rake fixtures:certs
 ```
 
-Files signed with these test certificates will include a `signingCredential.untrusted` validation warning since the test CA is not in the public trust list, but are otherwise valid for development purposes.
-
-### Production
-
-Obtain a certificate from a CA trusted by the C2PA ecosystem. The certificate file must contain the full chain (end-entity certificate first, then any intermediates), but must **not** include the root CA.
+They land in `test/fixtures/certs/` and are not committed. See
+[`test/fixtures/generate_certs.rb`](test/fixtures/generate_certs.rb) for a
+worked example of building a chain c2pa-rs accepts.
 
 The supported signing algorithms are: `es256`, `es384`, `es512`, `ps256`, `ps384`, `ps512`, `ed25519`.
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,54 @@ rescue C2PA::Error => e
 end
 ```
 
+## Configuring trust
+
+c2pa-rs checks the signing certificate against a trust list, and reports
+`Trusted` when it chains to a root that list contains. That happens by default,
+so a certificate from a CA in the C2PA trust list needs no configuration.
+
+For a private or enterprise CA, add its root:
+
+```ruby
+C2PA.configure do |config|
+  config.trust_anchors = "ca/root.pem"   # a path, or the PEM text itself
+end
+```
+
+Files signed by a certificate chaining to it then validate as `Trusted` rather
+than carrying `signingCredential.untrusted`.
+
+### Offline and air-gapped environments
+
+Reading an asset may fetch a remote manifest over the network, and revocation
+checking may contact an OCSP responder. Both can be turned off:
+
+```ruby
+C2PA.configure do |config|
+  config.remote_manifest_fetch = false
+  config.ocsp_fetch            = false
+end
+```
+
+### Everything configurable
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `trust_anchors` | none | additional roots to trust, as PEM |
+| `trust_list` | C2PA list | replaces the trust list rather than adding to it |
+| `allowed_certificates` | none | explicitly allowed certificates, as PEM |
+| `verify_trust` | `true` | whether trust is checked at all |
+| `remote_manifest_fetch` | `true` | whether reading may fetch over the network |
+| `ocsp_fetch` | `false` | whether revocation is checked over OCSP |
+
+Settings are global and apply to subsequent calls. Only values you set are
+sent, so anything left alone keeps c2pa-rs's own default. `C2PA.configure` with
+no block resets everything.
+
+Turning `verify_trust` off means nothing is ever reported as untrusted, which
+in a library for establishing provenance is rarely what you want. It exists for
+environments that cannot reach a trust list at all.
+
 ## Supported file formats
 
 Each format below has a fixture and a signing test in the suite: the file is

--- a/ext/c2pa_native/src/lib.rs
+++ b/ext/c2pa_native/src/lib.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, RwLock, OnceLock};
 use c2pa::{create_signer, Builder, BuilderIntent, Context, Reader, SigningAlg};
 use magnus::{function, prelude::*, Error, Ruby};
 
@@ -17,9 +17,33 @@ use magnus::{function, prelude::*, Error, Ruby};
 //
 // It currently carries defaults. Exposing settings to Ruby is a separate piece
 // of work; this is the seam that makes it possible.
-fn shared_context() -> &'static Arc<Context> {
-    static CONTEXT: OnceLock<Arc<Context>> = OnceLock::new();
-    CONTEXT.get_or_init(|| Context::new().into_shared())
+fn context_slot() -> &'static RwLock<Arc<Context>> {
+    static CONTEXT: OnceLock<RwLock<Arc<Context>>> = OnceLock::new();
+    CONTEXT.get_or_init(|| RwLock::new(Context::new().into_shared()))
+}
+
+fn shared_context() -> Arc<Context> {
+    context_slot()
+        .read()
+        .expect("context lock poisoned")
+        .clone()
+}
+
+// Replace the shared Context with one built from the supplied settings.
+//
+// c2pa-rs takes settings as JSON, so the Ruby side assembles the document and
+// this only has to validate and install it. Rebuilding rather than mutating
+// keeps the Context immutable once shared: signing already in flight on another
+// thread continues against the settings it started with.
+fn do_configure(settings_json: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let context = Context::new()
+        .with_settings(settings_json)
+        .map_err(|e| format!("Invalid settings: {}", e))?
+        .into_shared();
+
+    *context_slot().write().map_err(|_| "context lock poisoned")? = context;
+
+    Ok(())
 }
 
 fn alg_from_str(alg: &str) -> Result<SigningAlg, String> {
@@ -82,7 +106,7 @@ fn do_sign_file(
     let default_json = format!(r#"{{"title": "{}"}}"#, title);
     let json = manifest_json.unwrap_or(&default_json);
 
-    let mut builder = Builder::from_shared_context(shared_context())
+    let mut builder = Builder::from_shared_context(&shared_context())
         .with_definition(json)
         .map_err(|e| format!("Invalid manifest JSON: {}", e))?;
 
@@ -97,7 +121,7 @@ fn do_sign_file(
 }
 
 fn do_read_file(path: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let reader = Reader::from_shared_context(shared_context())
+    let reader = Reader::from_shared_context(&shared_context())
         .with_file(path)
         .map_err(|e| format!("Failed to read manifest from '{}': {}", path, e))?;
     Ok(reader.json())
@@ -127,6 +151,15 @@ fn read_file(path: String) -> Result<String, Error> {
         .map_err(|e| Error::new(Ruby::get().expect("called from Ruby thread").exception_runtime_error(), e.to_string()))
 }
 
+fn configure(settings_json: String) -> Result<(), Error> {
+    do_configure(&settings_json).map_err(|e| {
+        Error::new(
+            Ruby::get().expect("called from Ruby thread").exception_runtime_error(),
+            e.to_string(),
+        )
+    })
+}
+
 fn sdk_version() -> String {
     c2pa::VERSION.to_string()
 }
@@ -140,6 +173,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
 
     native.define_singleton_method("sign_file", function!(sign_file, 7))?;
     native.define_singleton_method("read_file", function!(read_file, 1))?;
+    native.define_singleton_method("configure", function!(configure, 1))?;
     native.define_singleton_method("sdk_version", function!(sdk_version, 0))?;
 
     Ok(())

--- a/lib/c2pa.rb
+++ b/lib/c2pa.rb
@@ -3,6 +3,7 @@ require_relative "c2pa/version"
 require_relative "c2pa/error"
 require_relative "c2pa/actions"
 require_relative "c2pa/digital_source_types"
+require_relative "c2pa/config"
 require_relative "c2pa/manifest"
 require "c2pa/c2pa_native"
 
@@ -13,6 +14,39 @@ module C2PA
   # the active trust list. Accepting only "Valid" would reject exactly the
   # production files that are most correct.
   VALID_STATES = %w[Valid Trusted].freeze
+
+  # Configure how c2pa-rs validates.
+  #
+  # Settings are global and take effect for subsequent calls. Signing already
+  # in flight on another thread continues against the settings it started
+  # with, since the underlying context is replaced rather than mutated.
+  #
+  # @yieldparam config [C2PA::Config]
+  # @return [C2PA::Config] the configuration that was applied
+  # @raise [C2PA::InvalidSettingsError] if the settings are not usable
+  #
+  # @example Trusting a private CA
+  #   C2PA.configure do |config|
+  #     config.trust_anchors = "ca/root.pem"
+  #   end
+  #
+  # @example An offline environment
+  #   C2PA.configure do |config|
+  #     config.remote_manifest_fetch = false
+  #     config.ocsp_fetch = false
+  #   end
+  def self.configure
+    config = Config.new
+    yield config if block_given?
+
+    begin
+      Native.configure(config.to_json)
+    rescue RuntimeError => e
+      raise InvalidSettingsError, e.message
+    end
+
+    config
+  end
 
   # Sign a file with a C2PA manifest.
   #

--- a/lib/c2pa/config.rb
+++ b/lib/c2pa/config.rb
@@ -1,0 +1,90 @@
+require "json"
+
+module C2PA
+  # Settings that govern how c2pa-rs validates.
+  #
+  # These reach the SDK through its Context, which is rebuilt whenever they
+  # change. Signing already in flight on another thread continues against the
+  # settings it started with.
+  #
+  # Defaults are c2pa-rs's own, so a gem that never calls C2PA.configure
+  # behaves exactly as it did before this existed.
+  class Config
+    # Additional root certificates to trust, as a PEM bundle. Use this for a
+    # private or enterprise CA: a certificate chaining to one of these
+    # validates as "Trusted" rather than carrying signingCredential.untrusted.
+    attr_accessor :trust_anchors
+
+    # The trust list proper — normally the C2PA-recognised anchors. Setting
+    # this replaces that list rather than adding to it, so prefer
+    # trust_anchors unless you mean to substitute the whole thing.
+    attr_accessor :trust_list
+
+    # Explicitly allowed certificates, as a PEM bundle.
+    attr_accessor :allowed_certificates
+
+    # Whether to check certificates against the trust list at all.
+    #
+    # Turning this off means nothing is ever reported as untrusted, which in a
+    # library for establishing provenance is rarely what you want. It exists
+    # for offline and air-gapped environments.
+    attr_accessor :verify_trust
+
+    # Whether reading an asset may fetch a manifest over the network.
+    # c2pa-rs defaults this to true, so reading can make an outbound request.
+    attr_accessor :remote_manifest_fetch
+
+    # Whether to check certificate revocation over OCSP, which also makes
+    # network requests.
+    attr_accessor :ocsp_fetch
+
+    def initialize
+      @trust_anchors = nil
+      @trust_list = nil
+      @allowed_certificates = nil
+      @verify_trust = nil
+      @remote_manifest_fetch = nil
+      @ocsp_fetch = nil
+    end
+
+    # The settings document c2pa-rs expects.
+    #
+    # Only values that were actually set are included, so anything left alone
+    # keeps the SDK's default rather than being pinned to ours.
+    #
+    # @return [String] JSON
+    def to_json
+      trust = {}
+      trust["user_anchors"] = read_pem(@trust_anchors)        unless @trust_anchors.nil?
+      trust["trust_anchors"] = read_pem(@trust_list)          unless @trust_list.nil?
+      trust["allowed_list"] = read_pem(@allowed_certificates) unless @allowed_certificates.nil?
+
+      verify = {}
+      verify["verify_trust"] = @verify_trust                   unless @verify_trust.nil?
+      verify["remote_manifest_fetch"] = @remote_manifest_fetch unless @remote_manifest_fetch.nil?
+      verify["ocsp_fetch"] = @ocsp_fetch                       unless @ocsp_fetch.nil?
+
+      settings = {}
+      settings["trust"] = trust unless trust.empty?
+      settings["verify"] = verify unless verify.empty?
+
+      JSON.generate(settings)
+    end
+
+    private
+
+    # Accept either PEM text or a path to a file containing it, since callers
+    # naturally have one or the other.
+    def read_pem(value)
+      string = value.to_s
+      return string if string.include?("BEGIN CERTIFICATE")
+
+      unless File.exist?(string)
+        raise InvalidSettingsError,
+              "expected PEM text or a readable file, got #{string.inspect}"
+      end
+
+      File.read(string)
+    end
+  end
+end

--- a/lib/c2pa/error.rb
+++ b/lib/c2pa/error.rb
@@ -3,4 +3,7 @@ module C2PA
   class SigningError < Error; end
   class ReadError < Error; end
   class InvalidManifestError < Error; end
+
+  # Raised when C2PA.configure is given something it cannot use.
+  class InvalidSettingsError < Error; end
 end

--- a/test/c2pa_test.rb
+++ b/test/c2pa_test.rb
@@ -404,6 +404,136 @@ class C2PATest < Minitest::Test
     end
   end
 
+  # ─── Trust configuration ───────────────────────────────────────────────────
+  #
+  # Before this existed the gem could not reach "Trusted" at all — c2pa-rs
+  # checks trust by default, but only against roots it already knows, and there
+  # was no way to add one. Anyone running a private PKI, which is a plausible
+  # case for a content-authenticity library inside an organisation, got
+  # signingCredential.untrusted with no recourse.
+  #
+  # Settings are global, so each test here resets them afterwards.
+
+  # A chain whose root we keep, so it can be added as a trust anchor.
+  def generate_trusted_chain(dir)
+    require_relative "fixtures/generate_certs"
+    key = -> { OpenSSL::PKey::EC.generate("prime256v1") }
+
+    root_key = key.call
+    root = CertificateFixtures.build("Root CA", nil, nil, root_key,
+                                     CertificateFixtures::CA_EXTENSIONS)
+    im_key = key.call
+    im = CertificateFixtures.build(
+      "Intermediate CA", root, root_key, im_key,
+      CertificateFixtures::CA_EXTENSIONS.merge("authorityKeyIdentifier" => ["keyid:always", false])
+    )
+    ee_key = key.call
+    ee = CertificateFixtures.build(
+      "Signer", im, im_key, ee_key,
+      CertificateFixtures::EE_EXTENSIONS.merge("authorityKeyIdentifier" => ["keyid:always", false])
+    )
+
+    chain = File.join(dir, "chain.pub")
+    key_file = File.join(dir, "key.pem")
+    root_file = File.join(dir, "root.pem")
+    File.write(chain, ee.to_pem + im.to_pem)
+    File.write(key_file, ee_key.private_to_pem)
+    File.write(root_file, root.to_pem)
+    [chain, key_file, root_file]
+  end
+
+  def state_signing_with(chain, key, dir, name)
+    output = File.join(dir, "#{name}.jpg")
+    C2PA.sign(file: File.join(FIXTURES, "tiny.jpg"), output: output,
+              certificate: chain, key: key, manifest: created_manifest)
+    C2PA.read(file: output)["validation_state"]
+  end
+
+  def test_a_configured_trust_anchor_yields_a_trusted_result
+    assert_certificates_present
+    dir = Dir.mktmpdir
+    chain, key, root = generate_trusted_chain(dir)
+
+    assert_equal "Valid", state_signing_with(chain, key, dir, "before"),
+                 "an unknown CA should not be trusted"
+
+    C2PA.configure { |config| config.trust_anchors = root }
+
+    assert_equal "Trusted", state_signing_with(chain, key, dir, "after"),
+                 "adding the root as a trust anchor should produce Trusted"
+  ensure
+    C2PA.configure
+    FileUtils.remove_entry(dir) if dir && File.exist?(dir)
+  end
+
+  def test_configuration_can_be_reset
+    assert_certificates_present
+    dir = Dir.mktmpdir
+    chain, key, root = generate_trusted_chain(dir)
+
+    C2PA.configure { |config| config.trust_anchors = root }
+    assert_equal "Trusted", state_signing_with(chain, key, dir, "configured")
+
+    C2PA.configure
+    assert_equal "Valid", state_signing_with(chain, key, dir, "reset"),
+                 "resetting should restore the default trust list"
+  ensure
+    C2PA.configure
+    FileUtils.remove_entry(dir) if dir && File.exist?(dir)
+  end
+
+  def test_trust_anchors_accept_pem_text_as_well_as_a_path
+    assert_certificates_present
+    dir = Dir.mktmpdir
+    chain, key, root = generate_trusted_chain(dir)
+
+    C2PA.configure { |config| config.trust_anchors = File.read(root) }
+
+    assert_equal "Trusted", state_signing_with(chain, key, dir, "inline")
+  ensure
+    C2PA.configure
+    FileUtils.remove_entry(dir) if dir && File.exist?(dir)
+  end
+
+  def test_trust_verification_can_be_disabled
+    assert_certificates_present
+    C2PA.configure { |config| config.verify_trust = false }
+
+    read_back(created_manifest) do |_, result|
+      codes = Array(result.dig("validation_results", "activeManifest", "failure"))
+              .map { |failure| failure["code"] }
+      refute_includes codes, "signingCredential.untrusted",
+                      "with trust checking off, nothing should be reported as untrusted"
+    end
+  ensure
+    C2PA.configure
+  end
+
+  def test_an_unusable_trust_anchor_raises
+    error = assert_raises(C2PA::InvalidSettingsError) do
+      C2PA.configure { |config| config.trust_anchors = "/nonexistent/ca.pem" }
+    end
+    assert_match(/PEM text or a readable file/, error.message)
+  ensure
+    C2PA.configure
+  end
+
+  # Only what the caller sets is sent, so anything untouched keeps c2pa-rs's
+  # default rather than being pinned to ours.
+  def test_an_empty_configuration_sends_no_settings
+    assert_equal "{}", C2PA::Config.new.to_json
+  end
+
+  def test_network_fetches_can_be_disabled
+    config = C2PA::Config.new
+    config.remote_manifest_fetch = false
+    config.ocsp_fetch = false
+
+    settings = JSON.parse(config.to_json)
+    assert_equal false, settings.dig("verify", "remote_manifest_fetch")
+    assert_equal false, settings.dig("verify", "ocsp_fetch")
+  end
+
   # ─── Concurrency ───────────────────────────────────────────────────────────
   #
   # The native layer shares one c2pa-rs Context across calls. The entry points


### PR DESCRIPTION
Closes #34

c2pa-rs checks certificate trust by default and reports `Trusted` when a certificate chains to a root in its trust list. The gem could not change that list — so anyone running a private or enterprise CA got `signingCredential.untrusted` with no recourse, and **`Trusted` was unreachable from Ruby entirely**.

```ruby
C2PA.configure do |config|
  config.trust_anchors = "ca/root.pem"   # a path, or the PEM text itself
end
```

Demonstrated rather than asserted — the test generates a CA, signs with it, and checks both states:

```
before configure: Valid
after configure:  Trusted
```

That also closes something left hanging from #12: `VALID_STATES` accepts `Trusted`, and until now nothing in the suite could produce it, so the branch was untested. It is now.

## Also configurable

| Setting | Default | |
|---|---|---|
| `trust_anchors` | none | additional roots to trust |
| `trust_list` | C2PA list | replaces the list rather than adding |
| `allowed_certificates` | none | explicitly allowed certificates |
| `verify_trust` | `true` | whether trust is checked at all |
| `remote_manifest_fetch` | `true` | whether reading may fetch over the network |
| `ocsp_fetch` | `false` | whether revocation is checked over OCSP |

`remote_manifest_fetch` matters more than it looks: it defaults to `true` in c2pa-rs, so **reading an asset could make an outbound HTTP request** with no way for a caller to prevent it. That is now controllable, which an air-gapped deployment needs.

## Defaults are untouched

Only values the caller sets are sent, so anything left alone keeps c2pa-rs's default rather than being pinned to ours. An empty configuration sends `{}`, and `C2PA.configure` with no block resets.

## The payoff from #17

Settings replace the shared `Context` rather than mutating it, so signing already in flight on another thread continues against the settings it started with. That the Context existed to be replaced is exactly what #17 built.

## README corrections

The certificate section said certificates must chain to a CA in the C2PA ecosystem and that self-signed ones are rejected. This feature contradicts the first, and the second was imprecise — a bare self-signed certificate is rejected for failing the **certificate profile**, not for being self-signed. The missing piece is usually an Authority Key Identifier, which `openssl x509 -req` omits by default, producing only `the certificate is invalid`. The profile requirements are now listed, since working them out cost real time.

## Verified to fail (#10 discipline)

| Mutation | Result |
|---|---|
| Trust anchors never sent | 4 failures |
| `verify_trust` never sent | 1 failure |
| Unreadable anchor silently accepted | 1 failure |
| `configure` does not reach the native layer | 5 failures |
| *(control)* | **0 failures** |

94 runs, 279 assertions, 0 failures, 0 skips.